### PR TITLE
feature: add error message and job event in confirm func

### DIFF
--- a/job.go
+++ b/job.go
@@ -6,15 +6,15 @@ import (
 
 // Possible job states.
 const (
-	JobStatusCreated    JobStatus = "CREATED"
-	JobStatusConfirmed  JobStatus = "CONFIRMED"
-	JobStatusResolving  JobStatus = "RESOLVING"
-	JobStatusReady      JobStatus = "READY"
-	JobStatusProcessing JobStatus = "PROCESSING"
-	JobStatusDone       JobStatus = "DONE"
-	JobStatusFailed     JobStatus = "FAILED"
-	JobStatusAborted    JobStatus = "ABORTED"
-	JobStatusCanceled   JobStatus = "CANCELED"
+	JobStatusCreated         JobStatus = "CREATED"
+	JobStatusConfirmed       JobStatus = "CONFIRMED"
+	JobStatusResolving       JobStatus = "RESOLVING"
+	JobStatusReady           JobStatus = "READY"
+	JobStatusProcessing      JobStatus = "PROCESSING"
+	JobStatusDone            JobStatus = "DONE"
+	JobStatusFailed          JobStatus = "FAILED"
+	JobStatusAborted         JobStatus = "ABORTED"
+	JobStatusConfirmCanceled JobStatus = "CONFIRM_CANCELED"
 )
 
 type (

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -688,14 +688,14 @@ func TestDecodeValueVariants(t *testing.T) {
 			UpdatedAt: now,
 			Values: map[string]any{
 				"type":          "foo",
-				"status":        orbital.JobStatusCanceled,
+				"status":        orbital.JobStatusConfirmCanceled,
 				"data":          []byte("x"),
 				"error_message": "error",
 			},
 		}
 		job, err := orbital.Decode[orbital.Job](e)
 		assert.NoError(t, err)
-		assert.Equal(t, orbital.JobStatusCanceled, job.Status)
+		assert.Equal(t, orbital.JobStatusConfirmCanceled, job.Status)
 	})
 
 	t.Run("status as string type", func(t *testing.T) {

--- a/repository_test.go
+++ b/repository_test.go
@@ -682,7 +682,7 @@ func TestRepoTransactionRaceCondition(t *testing.T) {
 
 			err := orbital.Transaction(repo)(ctx, func(ctx context.Context, repo orbital.Repository) error {
 				// should update the job as cancel
-				createdJob.Status = orbital.JobStatusCanceled
+				createdJob.Status = orbital.JobStatusConfirmCanceled
 				err := orbital.UpdateRepoJob(&repo)(ctx, createdJob)
 				assert.NoError(t, err)
 
@@ -703,7 +703,7 @@ func TestRepoTransactionRaceCondition(t *testing.T) {
 
 		// should fetch the updated job for the second transaction
 		jobs, err := orbital.ListRepoJobs(repo)(ctx, orbital.ListJobsQuery{
-			Status:    orbital.JobStatusCanceled,
+			Status:    orbital.JobStatusConfirmCanceled,
 			CreatedAt: utcUnix(),
 			Limit:     10,
 		})


### PR DESCRIPTION


<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       breaking|feature|doc|build|chore|ci|docs|feature|fix|perf|refactor|revert|style|test
- description:   
-->

**What this PR does / why we need it**:
``` Detailed description of PR; If no description, remove the block.
Update job confirmation logic,
tests, and related assertions to use the status and propagate canceled error 
messages from the confirmation function to the job. Create job event if the 
confirmation func is not confirmed. Also remove custom context.
```



**Release note**:
``` Release notes; If no release note is required, just write "NONE" within the block.
NONE
```
