### PR TITLE
feature: add error message field to Task model

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -603,6 +603,9 @@ func (m *Manager) processResponse(ctx context.Context, resp TaskResponse) error 
 		task.ETag = uuid.NewString() // Generate a new ETag for the updated task
 		task.Status = TaskStatus(resp.Status)
 		task.ReconcileAfterSec = resp.ReconcileAfterSec
+		if task.Status == TaskStatusFailed {
+			task.ErrorMessage = resp.ErrorMessage
+		}
 
 		return repo.updateTask(txCtx, task)
 	})

--- a/mapper.go
+++ b/mapper.go
@@ -137,6 +137,7 @@ func Encode[T EntityTypes](entityType T) (Entity, error) {
 				"etag":                obj.ETag,
 				"status":              obj.Status,
 				"target":              obj.Target,
+				"error_message":       obj.ErrorMessage,
 				"updated_at":          obj.UpdatedAt,
 				"created_at":          obj.CreatedAt,
 			},
@@ -281,6 +282,9 @@ func decodeTask[T EntityTypes](e Entity) (T, error) {
 		return empty, err
 	}
 	if t.ReconcileAfterSec, err = resolve[int64](vals, "reconcile_after_sec"); err != nil {
+		return empty, err
+	}
+	if t.ErrorMessage, err = resolve[string](vals, "error_message"); err != nil {
 		return empty, err
 	}
 	return out, nil

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -248,9 +248,10 @@ func TestEncodes(t *testing.T) {
 	t.Run("success Task", func(t *testing.T) {
 		input := []orbital.Task{
 			{
-				ID:        uID,
-				CreatedAt: unixTime,
-				UpdatedAt: unixTime,
+				ID:           uID,
+				CreatedAt:    unixTime,
+				UpdatedAt:    unixTime,
+				ErrorMessage: "foo-error",
 			},
 		}
 		expected := []orbital.Entity{
@@ -260,13 +261,21 @@ func TestEncodes(t *testing.T) {
 				CreatedAt: unixTime,
 				UpdatedAt: unixTime,
 				Values: map[string]any{
-					"id":            uID,
-					"created_at":    unixTime,
-					"updated_at":    unixTime,
-					"working_state": []byte(nil), "data": []byte(nil), "type": "", "etag": "", "job_id": uuid.Nil,
-					"last_sent_at": int64(0), "reconcile_after_sec": int64(0), "sent_count": int64(0),
-					"max_sent_count": int64(0), "status": orbital.TaskStatus(""),
-					"target": "",
+					"id":                  uID,
+					"created_at":          unixTime,
+					"updated_at":          unixTime,
+					"working_state":       []byte(nil),
+					"data":                []byte(nil),
+					"type":                "",
+					"etag":                "",
+					"job_id":              uuid.Nil,
+					"last_sent_at":        int64(0),
+					"reconcile_after_sec": int64(0),
+					"sent_count":          int64(0),
+					"max_sent_count":      int64(0),
+					"status":              orbital.TaskStatus(""),
+					"target":              "",
+					"error_message":       "foo-error",
 				},
 			},
 		}
@@ -439,6 +448,7 @@ func TestDecodes(t *testing.T) {
 				ETag:              "etag-1",
 				Status:            orbital.TaskStatusCreated,
 				Target:            "target-1",
+				ErrorMessage:      "error-message-1",
 				UpdatedAt:         utcUnix(),
 				CreatedAt:         utcUnix(),
 			}
@@ -453,6 +463,7 @@ func TestDecodes(t *testing.T) {
 				ETag:              "etag-2",
 				Status:            orbital.TaskStatusCreated,
 				Target:            "target-2",
+				ErrorMessage:      "error-message-2",
 				UpdatedAt:         utcUnix(),
 				CreatedAt:         utcUnix(),
 			}
@@ -517,6 +528,10 @@ func TestDecodes(t *testing.T) {
 					name:        "missing reconcile_after_sec",
 					keyToDelete: "reconcile_after_sec",
 				},
+				{
+					name:        "missing error_message",
+					keyToDelete: "error_message",
+				},
 			}
 
 			for _, tt := range tts {
@@ -540,6 +555,7 @@ func TestDecodes(t *testing.T) {
 							"etag":                "etag",
 							"status":              "status",
 							"target":              "target",
+							"error_message":       "error",
 							"updated_at":          0,
 							"created_at":          0,
 						},

--- a/repository_test.go
+++ b/repository_test.go
@@ -286,11 +286,12 @@ func TestRepoCreateTasks(t *testing.T) {
 		tasks = append(tasks, orbital.Task{
 			JobID:        jobID,
 			Type:         taskType,
-			WorkingState: []byte(fmt.Sprintf("working-state-%v", index)),
+			WorkingState: fmt.Append([]byte("working-state-"), index),
 			SentCount:    int64(index),
 			ETag:         fmt.Sprintf("etag-%v", index),
 			Status:       orbital.TaskStatusCreated,
 			Target:       fmt.Sprintf("target-%v", index),
+			ErrorMessage: fmt.Sprintf("error-message-%v", index),
 		})
 	}
 
@@ -304,9 +305,10 @@ func TestRepoCreateTasks(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, jobID, fetchedTask.JobID)
 		assert.Equal(t, taskType, fetchedTask.Type)
-		assert.Equal(t, []byte(fmt.Sprintf("working-state-%v", index)), fetchedTask.WorkingState)
+		assert.Equal(t, fmt.Sprintf("working-state-%v", index), string(fetchedTask.WorkingState))
 		assert.Equal(t, int64(index), fetchedTask.SentCount)
 		assert.Equal(t, fmt.Sprintf("etag-%v", index), fetchedTask.ETag)
+		assert.Equal(t, fmt.Sprintf("error-message-%v", index), fetchedTask.ErrorMessage)
 		assert.Equal(t, orbital.TaskStatusCreated, fetchedTask.Status)
 	}
 }

--- a/store/sql/sql.go
+++ b/store/sql/sql.go
@@ -51,6 +51,7 @@ func New(ctx context.Context, db *sql.DB) (*SQL, error) {
    			etag VARCHAR(100),
    			status VARCHAR(100) NOT NULL,
    			target TEXT NOT NULL,
+     		error_message VARCHAR(250),
    			updated_at BIGINT NOT NULL,
    			created_at BIGINT NOT NULL
    		);

--- a/task.go
+++ b/task.go
@@ -32,6 +32,7 @@ type Task struct {
 	ETag              string
 	Status            TaskStatus
 	Target            string
+	ErrorMessage      string
 	UpdatedAt         int64
 	CreatedAt         int64
 }


### PR DESCRIPTION

<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       breaking|feature|doc|build|chore|ci|docs|feature|fix|perf|refactor|revert|style|test
- description:   <short description of the PR>
-->

**What this PR does / why we need it**:
``` Detailed description of PR; If no description, remove the block.
Introduce an  field to the  struct and update all
relevant code paths, including encoding/decoding, database schema, 
and tests. This allows tasks to store and retrieve error messages, 
improving error tracking and debugging. 
The field is only set when the task status is Failed. 
All test cases and assertions are updated to reflect this change.
```

**Release note**:
``` Release notes; If no release note is required, just write "NONE" within the block.
A new column is  added in task table.
```
