### PR TITLE
test(sql): improve concurrency test for retrieval mode update

### DIFF
--- a/store/sql/sql_test.go
+++ b/store/sql/sql_test.go
@@ -949,7 +949,7 @@ func TestWithRetrievalModeQueue(t *testing.T) {
 			err := store.Transaction(ctx, func(ctx context.Context, r orbital.Repository) error {
 				// here we check if the first transaction is in stage 1
 				assert.Equal(t, int32(1), firstTransactionStage.Load())
-				transactor2 <- "transaction 1 continue"
+				transactor2 <- "transaction 1 can continue"
 				listResult, err := r.Store.List(ctx, queryWithRetrievalModeUpdate)
 				// following assert makes sure that we are able to fetch the record
 				assert.NoError(t, err)
@@ -965,7 +965,7 @@ func TestWithRetrievalModeQueue(t *testing.T) {
 		transactor1 <- "transaction 1 start"
 		assert.Equal(t, "transaction 1 wait", <-transactor1)
 		transactor2 <- "transaction 2 start"
-		assert.Equal(t, "transaction 1 continue", <-transactor2)
+		assert.Equal(t, "transaction 1 can continue", <-transactor2)
 		transactor1 <- "transaction 1 continue"
 		wg.Wait()
 	})


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       breaking|feature|doc|build|chore|ci|docs|feature|fix|perf|refactor|revert|style|test
- description:   <short description of the PR>
-->

**What this PR does / why we need it**:
``` Detailed description of PR; If no description, remove the block. 
There was a data race which was happening in the test. 


So Refactored TestWithRetrievalModeUpdate to use atomic stage tracking instead 
of entity assignment for better concurrency control. Updated transaction coordination
 logic to ensure correct sequencing and assertions, improving test reliability and clarity.

```



**Release note**:
``` Release notes; If no release note is required, just write "NONE" within the block.

```
