### PR TITLE
test: add test containers and remove build tags from tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,22 @@ db_pass = secret
 db_name = orbital
 config = DB_HOST=$(db_host) DB_PORT=$(db_port) DB_USER=$(db_user) DB_PASS=$(db_pass) DB_NAME=$(db_name)
 
-test: docker-compose-up
-	$(config) go test -v -p 1 -count=1 -race -shuffle=on -coverprofile=cover.out ./...
+# The tests use go-testcontainers, which require Docker to be running. 
+# Additional setup may be needed depending on your system, refer to https://golang.testcontainers.org/system_requirements/ for details.
 
+# run tests
+test:
+	go test -p 1 -count=1 -race -shuffle=on -coverprofile=cover.out ./...
+
+# run tests with verbose output
+test-verbose:
+	go test -v -p 1 -count=1 -race -shuffle=on -coverprofile=cover.out ./...	
+
+# run specific test function defined by TEST_FUNC variable
+test-single:
+	go test -p 1 -count=1 -race -shuffle=on -coverprofile=cover.out -run $(TEST_FUNC) ./...
+
+# run integration tests
 test-integration:
 	go test -tags=integration ./integration/... -v
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -1,47 +1,62 @@
-//go:build integration
-// +build integration
-
 package orbital_test
 
 import (
-	stdsql "database/sql"
+	"context"
 	"fmt"
+	"log"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	_ "github.com/lib/pq"
+
+	stdsql "database/sql"
 
 	"github.com/openkcm/orbital/store/sql"
 )
 
-var (
-	host     = os.Getenv("DB_HOST")
-	port     = os.Getenv("DB_PORT")
-	user     = os.Getenv("DB_USER")
-	password = os.Getenv("DB_PASS")
-	dbname   = os.Getenv("DB_NAME")
+const (
+	host     = "localhost"
+	user     = "postgres"
+	password = "secret"
+	dbname   = "orbital"
 	sslmode  = "disable"
 )
 
-func init() {
-	if host == "" {
-		host = "localhost"
+var port = "5432"
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+
+	pgContainer, err := postgres.Run(ctx, "postgres:17-alpine",
+		postgres.WithDatabase(dbname),
+		postgres.WithUsername(user),
+		postgres.WithPassword(password),
+		postgres.BasicWaitStrategies(),
+	)
+	if err != nil {
+		log.Println("Failed to start PostgreSQL container:", err)
+		os.Exit(1)
 	}
-	if port == "" {
-		port = "5432"
+
+	mappedPort, err := pgContainer.MappedPort(ctx, "5432")
+	if err != nil {
+		log.Println("Failed to get mapped port for PostgreSQL container:", err)
+		os.Exit(1)
 	}
-	if user == "" {
-		user = "postgres"
+	port = mappedPort.Port()
+
+	code := m.Run()
+
+	if err := pgContainer.Terminate(ctx); err != nil {
+		log.Println("Failed to terminate PostgreSQL container:", err)
+		os.Exit(1)
 	}
-	if password == "" {
-		password = "secret"
-	}
-	if dbname == "" {
-		dbname = "orbital"
-	}
+
+	os.Exit(code)
 }
 
 func clearTables(t *testing.T, db *stdsql.DB) {

--- a/jobevent_test.go
+++ b/jobevent_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package orbital_test
 
 import (

--- a/manager_test.go
+++ b/manager_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package orbital_test
 
 import (
@@ -897,7 +894,7 @@ func TestCancel(t *testing.T) {
 		assert.True(t, ok)
 
 		assert.Equal(t, orbital.JobStatusUserCanceled, job.Status)
-		assert.Equal(t, job.ErrorMessage, "job has been canceled by the user")
+		assert.Equal(t, "job has been canceled by the user", job.ErrorMessage)
 	})
 	t.Run("should not cancel job", func(t *testing.T) {
 		db, store := createSQLStore(t)
@@ -919,7 +916,7 @@ func TestCancel(t *testing.T) {
 		assert.True(t, ok)
 
 		assert.NotEqual(t, orbital.JobStatusUserCanceled, job.Status)
-		assert.Equal(t, job.ErrorMessage, "")
+		assert.Empty(t, job.ErrorMessage)
 	})
 	t.Run("job not found", func(t *testing.T) {
 		db, store := createSQLStore(t)

--- a/reconcile_test.go
+++ b/reconcile_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package orbital_test
 
 import (

--- a/repository_test.go
+++ b/repository_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package orbital_test
 
 import (

--- a/store/sql/helper_test.go
+++ b/store/sql/helper_test.go
@@ -1,47 +1,62 @@
-//go:build integration
-// +build integration
-
 package sql_test
 
 import (
-	stdsql "database/sql"
+	"context"
 	"fmt"
+	"log"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	_ "github.com/lib/pq"
+
+	stdsql "database/sql"
 
 	"github.com/openkcm/orbital/store/sql"
 )
 
-var (
-	host     = os.Getenv("DB_HOST")
-	port     = os.Getenv("DB_PORT")
-	user     = os.Getenv("DB_USER")
-	password = os.Getenv("DB_PASS")
-	dbname   = os.Getenv("DB_NAME")
+const (
+	host     = "localhost"
+	user     = "postgres"
+	password = "secret"
+	dbname   = "orbital"
 	sslmode  = "disable"
 )
 
-func init() {
-	if host == "" {
-		host = "localhost"
+var port = "5432"
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+
+	pgContainer, err := postgres.Run(ctx, "postgres:17-alpine",
+		postgres.WithDatabase(dbname),
+		postgres.WithUsername(user),
+		postgres.WithPassword(password),
+		postgres.BasicWaitStrategies(),
+	)
+	if err != nil {
+		log.Println("Failed to start PostgreSQL container:", err)
+		os.Exit(1)
 	}
-	if port == "" {
-		port = "5432"
+
+	mappedPort, err := pgContainer.MappedPort(ctx, "5432")
+	if err != nil {
+		log.Println("Failed to get mapped port for PostgreSQL container:", err)
+		os.Exit(1)
 	}
-	if user == "" {
-		user = "postgres"
+	port = mappedPort.Port()
+
+	code := m.Run()
+
+	if err := pgContainer.Terminate(ctx); err != nil {
+		log.Println("Failed to terminate PostgreSQL container:", err)
+		os.Exit(1)
 	}
-	if password == "" {
-		password = "secret"
-	}
-	if dbname == "" {
-		dbname = "orbital"
-	}
+
+	os.Exit(code)
 }
 
 func clearTables(t *testing.T, db *stdsql.DB) {

--- a/store/sql/sql_test.go
+++ b/store/sql/sql_test.go
@@ -1,11 +1,7 @@
-//go:build integration
-// +build integration
-
 package sql_test
 
 import (
 	"context"
-	stdsql "database/sql"
 	"errors"
 	"fmt"
 	"reflect"
@@ -17,6 +13,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+
+	stdsql "database/sql"
 
 	"github.com/openkcm/orbital"
 	"github.com/openkcm/orbital/store/query"


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       test
- description:   add test containers and remove build tags from tests
-->

**What this PR does / why we need it**:
This adds test containers to start a Postgres database, removes the temporary build tags that previously prevented tests with a Postgres dependency from running, updates the existing make rule, and adds two additional handy make rules.

**Special notes for your reviewer**:
This is a less intrusive change and allows all test cases (except for integration tests in the `integration` directory) to run again inside our CI pipeline. As discussed, we could consider parallelizing tests and isolating them with unique temporary databases to speed up testing.
