### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,6 @@
 name: Git
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/openkcm/orbital/security/code-scanning/1](https://github.com/openkcm/orbital/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by a job-specific `permissions` block. Based on the principle of least privilege, the `contents: read` permission is sufficient for most workflows that do not need to modify repository contents. If additional permissions are required, they can be added explicitly.

The `permissions` block should be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
