### PR TITLE
fix(amqp): Add close method to AMQP struct

### DIFF
--- a/client/amqp/amqp.go
+++ b/client/amqp/amqp.go
@@ -202,3 +202,23 @@ func (a *AMQP) ReceiveTaskResponse(ctx context.Context) (orbital.TaskResponse, e
 
 	return resp, nil
 }
+
+// Close closes the AMQP connection, sender, and receiver.
+func (a *AMQP) Close(ctx context.Context) error {
+	if a.receiver != nil {
+		if err := a.receiver.Close(ctx); err != nil {
+			return fmt.Errorf("failed to close receiver: %w", err)
+		}
+	}
+	if a.sender != nil {
+		if err := a.sender.Close(ctx); err != nil {
+			return fmt.Errorf("failed to close sender: %w", err)
+		}
+	}
+	if a.conn != nil {
+		if err := a.conn.Close(); err != nil {
+			return fmt.Errorf("failed to close connection: %w", err)
+		}
+	}
+	return nil
+}

--- a/client/amqp/amqp_test.go
+++ b/client/amqp/amqp_test.go
@@ -471,8 +471,8 @@ func startSolace(ctx context.Context, t *testing.T) (string, func()) {
 
 	// Even tought the container listens on port 5672, it may take more time
 	// for Solace to be ready to accept connections.
-	err = waitForSolaceReady(ctx, t, url)
-	assert.NoError(t, err, "waiting for Solace to be ready should not fail")
+	err = waitForClientReady(ctx, t, url)
+	assert.NoError(t, err, "waiting for client to be ready should not fail")
 
 	return url, func() {
 		err := cont.Terminate(ctx)
@@ -480,7 +480,7 @@ func startSolace(ctx context.Context, t *testing.T) (string, func()) {
 	}
 }
 
-func waitForSolaceReady(ctx context.Context, t *testing.T, url string) error {
+func waitForClientReady(ctx context.Context, t *testing.T, url string) error {
 	t.Helper()
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
@@ -493,7 +493,7 @@ func waitForSolaceReady(ctx context.Context, t *testing.T, url string) error {
 	for {
 		select {
 		case <-timeoutCtx.Done():
-			return fmt.Errorf("waiting for Solace to be ready: %w", lastErr)
+			return fmt.Errorf("waiting for client to be ready: %w", lastErr)
 		case <-ticker.C:
 			cli, err := amqp.NewClient(timeoutCtx, codec.JSON{}, amqp.ConnectionInfo{
 				URL:    url,
@@ -501,7 +501,7 @@ func waitForSolaceReady(ctx context.Context, t *testing.T, url string) error {
 				Source: "ready-check",
 			})
 			if err == nil {
-				// Successfully connected, Solace is ready.
+				// Successfully connected, client is ready.
 				return cli.Close(timeoutCtx)
 			}
 			lastErr = err

--- a/client/amqp/amqp_test.go
+++ b/client/amqp/amqp_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 
@@ -298,7 +297,8 @@ func TestWithMessageBroker(t *testing.T) {
 			files.rootCACertPath,
 			"localhost",
 		))
-		require.NoError(t, err)
+		assert.NoError(t, err)
+		defer closeClient(ctx, t, cli)
 
 		exp := orbital.TaskRequest{TaskID: uuid.New()}
 		assert.NoError(t, cli.SendTaskRequest(ctx, exp))
@@ -467,9 +467,45 @@ func startSolace(ctx context.Context, t *testing.T) (string, func()) {
 	port, err := cont.MappedPort(ctx, "5672")
 	assert.NoError(t, err)
 
-	return fmt.Sprintf("amqp://%s/", net.JoinHostPort(host, port.Port())), func() {
+	url := fmt.Sprintf("amqp://%s/", net.JoinHostPort(host, port.Port()))
+
+	// Even tought the container listens on port 5672, it may take more time
+	// for Solace to be ready to accept connections.
+	err = waitForSolaceReady(ctx, t, url)
+	assert.NoError(t, err, "waiting for Solace to be ready should not fail")
+
+	return url, func() {
 		err := cont.Terminate(ctx)
 		assert.NoError(t, err, "terminating Solace container should not fail")
+	}
+}
+
+func waitForSolaceReady(ctx context.Context, t *testing.T, url string) error {
+	t.Helper()
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		select {
+		case <-timeoutCtx.Done():
+			return fmt.Errorf("waiting for Solace to be ready: %w", lastErr)
+		case <-ticker.C:
+			cli, err := amqp.NewClient(timeoutCtx, codec.JSON{}, amqp.ConnectionInfo{
+				URL:    url,
+				Target: "ready-check",
+				Source: "ready-check",
+			})
+			if err == nil {
+				// Successfully connected, Solace is ready.
+				return cli.Close(timeoutCtx)
+			}
+			lastErr = err
+		}
 	}
 }
 
@@ -482,6 +518,7 @@ func testSendReceiveTaskRequests(t *testing.T, url, queue string) {
 		URL: url, Target: queue, Source: queue,
 	})
 	assert.NoError(t, err)
+	defer closeClient(ctx, t, cli)
 
 	const n = 5
 	exp := make([]orbital.TaskRequest, n)
@@ -505,6 +542,7 @@ func testSendReceiveTaskResponses(t *testing.T, url, queue string) {
 		URL: url, Target: queue, Source: queue,
 	})
 	assert.NoError(t, err)
+	defer closeClient(ctx, t, cli)
 
 	const n = 5
 	exp := make([]orbital.TaskResponse, n)
@@ -517,4 +555,11 @@ func testSendReceiveTaskResponses(t *testing.T, url, queue string) {
 		assert.NoError(t, err)
 		assert.Equal(t, exp[i].TaskID, got.TaskID)
 	}
+}
+
+func closeClient(ctx context.Context, t *testing.T, client *amqp.AMQP) {
+	t.Helper()
+
+	err := client.Close(ctx)
+	assert.NoError(t, err)
 }

--- a/examples/operator/main.go
+++ b/examples/operator/main.go
@@ -28,6 +28,7 @@ func main() {
 	// Initialize an AMQP client as the responder for handling task requests
 	responder, err := amqp.NewClient(ctx, codec.JSON{}, connInfo)
 	handleErr("initializing responder", err)
+	defer responder.Close(ctx)
 
 	// Initialize an orbital operator that uses the responder
 	operator, err := orbital.NewOperator(responder)

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/modules/rabbitmq"
@@ -181,6 +182,14 @@ func createAMQPClient(ctx context.Context, rabbitURL, target, source string) (*a
 	}
 
 	return client, nil
+}
+
+// closeClient closes the AMQP client connection.
+func closeClient(ctx context.Context, t *testing.T, client *amqp.AMQP) {
+	t.Helper()
+
+	err := client.Close(ctx)
+	assert.NoError(t, err, "failed to close AMQP client")
 }
 
 // createAndStartManager creates and starts a manager instance.

--- a/integration/reconciliation_test.go
+++ b/integration/reconciliation_test.go
@@ -94,9 +94,11 @@ func testReconcile(ctx context.Context, t *testing.T, env *testEnvironment, stor
 
 	managerClient, err := createAMQPClient(ctx, env.rabbitMQ.url, tasksQueue, responsesQueue)
 	assert.NoError(t, err)
+	defer closeClient(ctx, t, managerClient)
 
 	operatorClient, err := createAMQPClient(ctx, env.rabbitMQ.url, responsesQueue, tasksQueue)
 	assert.NoError(t, err)
+	defer closeClient(ctx, t, operatorClient)
 
 	operatorDone := make(chan struct{})
 	var operatorOnce sync.Once
@@ -254,13 +256,17 @@ func testReconcileWithMultipleTasks(ctx context.Context, t *testing.T, env *test
 
 	managerClient1, err := createAMQPClient(ctx, env.rabbitMQ.url, queue1, response1)
 	assert.NoError(t, err)
+	defer closeClient(ctx, t, managerClient1)
 	operatorClient1, err := createAMQPClient(ctx, env.rabbitMQ.url, response1, queue1)
 	assert.NoError(t, err)
+	defer closeClient(ctx, t, operatorClient1)
 
 	managerClient2, err := createAMQPClient(ctx, env.rabbitMQ.url, queue2, response2)
 	assert.NoError(t, err)
+	defer closeClient(ctx, t, managerClient2)
 	operatorClient2, err := createAMQPClient(ctx, env.rabbitMQ.url, response2, queue2)
 	assert.NoError(t, err)
+	defer closeClient(ctx, t, operatorClient2)
 
 	var operator1Once, operator2Once sync.Once
 	operator1Done := make(chan struct{})
@@ -450,8 +456,10 @@ func testTaskFailureScenario(ctx context.Context, t *testing.T, env *testEnviron
 
 	managerClient, err := createAMQPClient(ctx, env.rabbitMQ.url, tasksQueue, responsesQueue)
 	assert.NoError(t, err)
+	defer closeClient(ctx, t, managerClient)
 	operatorClient, err := createAMQPClient(ctx, env.rabbitMQ.url, responsesQueue, tasksQueue)
 	assert.NoError(t, err)
+	defer closeClient(ctx, t, operatorClient)
 
 	operatorDone := make(chan struct{})
 	var operatorOnce sync.Once
@@ -600,8 +608,10 @@ func testMultipleRequestResponseCycles(ctx context.Context, t *testing.T, env *t
 
 	managerClient, err := createAMQPClient(ctx, env.rabbitMQ.url, tasksQueue, responsesQueue)
 	assert.NoError(t, err)
+	defer closeClient(ctx, t, managerClient)
 	operatorClient, err := createAMQPClient(ctx, env.rabbitMQ.url, responsesQueue, tasksQueue)
 	assert.NoError(t, err)
+	defer closeClient(ctx, t, operatorClient)
 
 	managerConfig := managerConfig{
 		taskResolveFunc: func(_ context.Context, _ orbital.Job, _ orbital.TaskResolverCursor) (orbital.TaskResolverResult, error) {


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       fix
- description:   Add close method to AMQP struct

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
This adds a `Close` method to the `AMQP` struct to allow connections to be properly closed. Additionally, tests that require a Solace instance were flaky, so a custom waiting strategy was introduced to improve reliability.
