### PR TITLE
fix: update Etag when task is terminated

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.37.0
 	github.com/testcontainers/testcontainers-go/modules/rabbitmq v0.37.0
 	golang.org/x/sync v0.15.0
+	google.golang.org/protobuf v1.36.5
 )
 
 require (
@@ -62,6 +63,5 @@ require (
 	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	google.golang.org/grpc v1.70.0 // indirect
-	google.golang.org/protobuf v1.36.5 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/manager.go
+++ b/manager.go
@@ -515,6 +515,7 @@ func (m *Manager) handleTask(ctx context.Context, wg *sync.WaitGroup, repo Repos
 	defer wg.Done()
 
 	if task.SentCount >= task.MaxSentCount {
+		task.ETag = uuid.NewString()
 		task.Status = TaskStatusFailed
 		repo.updateTask(ctx, task) //nolint:errcheck
 		return

--- a/reconcile_test.go
+++ b/reconcile_test.go
@@ -325,11 +325,13 @@ func TestReconcile(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
+		beforeETag := uuid.NewString()
 		ids, err := orbital.CreateRepoTasks(repo)(ctx, []orbital.Task{
 			{
 				JobID:        job.ID,
 				Status:       orbital.TaskStatusCreated,
 				MaxSentCount: 0,
+				ETag:         beforeETag,
 			},
 		})
 		assert.NoError(t, err)
@@ -348,6 +350,7 @@ func TestReconcile(t *testing.T) {
 		actTask, ok, err := orbital.GetRepoTask(repo)(ctx, ids[0])
 		assert.NoError(t, err)
 		assert.True(t, ok)
+		assert.NotEqual(t, beforeETag, actTask.ETag)
 		assert.Equal(t, orbital.TaskStatusFailed, actTask.Status)
 	})
 }


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       fix
- description:   update Etag when task is terminated

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
This updates the ETag when the task is terminated on the manager side. This ensures that the terminated state remains unchanged, even if a response from the operator side arrives later.
