### PR TITLE
feat: reset ReconcileCount & LastReconcileAt on response process

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -623,6 +623,8 @@ func (m *Manager) processResponse(ctx context.Context, resp TaskResponse) error 
 		task.ETag = uuid.NewString() // Generate a new ETag for the updated task
 		task.Status = TaskStatus(resp.Status)
 		task.ReconcileAfterSec = resp.ReconcileAfterSec
+		task.LastReconciledAt = clock.NowUnixNano() // Update the last reconciled time to now unix to reset it.
+		task.ReconcileCount = 0                     // Reset the reconcile count since the task has been processed successfully.
 		task.TotalReceivedCount++
 		if task.Status == TaskStatusFailed {
 			task.ErrorMessage = resp.ErrorMessage

--- a/task.go
+++ b/task.go
@@ -22,11 +22,11 @@ type Task struct {
 	Type               string
 	Data               []byte
 	WorkingState       []byte
-	LastReconciledAt   int64
-	ReconcileCount     int64
+	LastReconciledAt   int64 // The last time the task was reconciled.
+	ReconcileCount     int64 // The number of times the task has been reconciled.
+	ReconcileAfterSec  int64 // The number of seconds after which the task should be reconciled.
 	TotalSentCount     int64
 	TotalReceivedCount int64
-	ReconcileAfterSec  int64
 	ETag               string
 	Status             TaskStatus
 	Target             string


### PR DESCRIPTION
Added logic to reset ReconcileCount to zero and update LastReconciledAt when a task response is processed. This ensures accurate tracking of task reconciliation cycles and improve reconciliation process. Enhanced related tests to verify correct state transitions and counter updates.

