### PR TITLE
fix!: align job confirm result with task resolve result

### DIFF
--- a/examples/manager/main.go
+++ b/examples/manager/main.go
@@ -102,7 +102,7 @@ func listTasks(ctx context.Context, manager *orbital.Manager, query orbital.List
 }
 
 func jobConfirmFunc(_ context.Context, _ orbital.Job) (orbital.JobConfirmResult, error) {
-	return orbital.JobConfirmResult{Confirmed: true}, nil
+	return orbital.JobConfirmResult{Done: true}, nil
 }
 
 func jobDoneEventFunc(_ context.Context, job orbital.Job) error {

--- a/integration/reconciliation_test.go
+++ b/integration/reconciliation_test.go
@@ -122,7 +122,7 @@ func testReconcile(ctx context.Context, t *testing.T, env *testEnvironment, stor
 		},
 		jobConfirmFunc: func(_ context.Context, job orbital.Job) (orbital.JobConfirmResult, error) {
 			t.Logf("JobConfirmFunc called for job %s", job.ID)
-			return orbital.JobConfirmResult{Confirmed: true}, nil
+			return orbital.JobConfirmResult{Done: true}, nil
 		},
 		targetClients: map[string]orbital.Initiator{
 			taskTarget: managerClient,
@@ -297,7 +297,7 @@ func testReconcileWithMultipleTasks(ctx context.Context, t *testing.T, env *test
 			}, nil
 		},
 		jobConfirmFunc: func(_ context.Context, _ orbital.Job) (orbital.JobConfirmResult, error) {
-			return orbital.JobConfirmResult{Confirmed: true}, nil
+			return orbital.JobConfirmResult{Done: true}, nil
 		},
 		targetClients: map[string]orbital.Initiator{
 			taskTarget1: managerClient1,
@@ -487,7 +487,7 @@ func testTaskFailureScenario(ctx context.Context, t *testing.T, env *testEnviron
 			}, nil
 		},
 		jobConfirmFunc: func(_ context.Context, _ orbital.Job) (orbital.JobConfirmResult, error) {
-			return orbital.JobConfirmResult{Confirmed: true}, nil
+			return orbital.JobConfirmResult{Done: true}, nil
 		},
 		targetClients: map[string]orbital.Initiator{
 			taskTarget: managerClient,
@@ -635,7 +635,7 @@ func testMultipleRequestResponseCycles(ctx context.Context, t *testing.T, env *t
 			}, nil
 		},
 		jobConfirmFunc: func(_ context.Context, _ orbital.Job) (orbital.JobConfirmResult, error) {
-			return orbital.JobConfirmResult{Confirmed: true}, nil
+			return orbital.JobConfirmResult{Done: true}, nil
 		},
 		targetClients: map[string]orbital.Initiator{
 			taskTarget: managerClient,

--- a/job.go
+++ b/job.go
@@ -7,6 +7,7 @@ import (
 // Possible job states.
 const (
 	JobStatusCreated         JobStatus = "CREATED"
+	JobStatusConfirming      JobStatus = "CONFIRMING"
 	JobStatusConfirmed       JobStatus = "CONFIRMED"
 	JobStatusResolving       JobStatus = "RESOLVING"
 	JobStatusReady           JobStatus = "READY"


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       fix
- description:   align job confirm result with task resolve result

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
These changes make the job confirmation result consistent with the task resolution result, reducing cognitive load and making the callback API easier to understand.
