### PR TITLE
fix: disable linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,6 +18,8 @@ linters:
     - wsl
     - mnd
     - ireturn
+    - noinlineerr
+    - wsl_v5
   settings:
     paralleltest:
       ignore-missing: true


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       fix
- description:   disable unnecessary linters

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
This disables the linters `noinlineerr` and `wsl_v5` which became available with version `v2.4.0`. Both enforce style rules that are inconsistent with our standards.
