### PR TITLE
feat: list jobs and run job once

### DIFF
--- a/examples/manager/main.go
+++ b/examples/manager/main.go
@@ -29,7 +29,7 @@ var (
 // This is a simple resource struct.
 type Resource struct {
 	ID   string
-	Data string
+	Data []byte
 }
 
 // This is a simple in-memory database to store resources.
@@ -69,13 +69,13 @@ func main() {
 	// Create and store a resource
 	resource := Resource{
 		ID:   uuid.NewString(),
-		Data: "resource-data",
+		Data: []byte("RESOURCE_DATA"),
 	}
 	resourceDB[resource.ID] = resource
 	log.Printf("Resource stored: %s\n", resource.ID)
 
 	// Prepare a job for the stored resource
-	job := orbital.NewJob(resource.Data, []byte("RESOURCE_CREATED"))
+	job := orbital.NewJob("CREATION", resource.Data, resource.ID)
 	createdJob, err := orbitalManager.PrepareJob(ctx, job)
 	handleErr("Failed to prepare job", err)
 

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
@@ -250,7 +251,7 @@ func createAndStartOperator(ctx context.Context, t *testing.T, responder orbital
 func createTestJob(ctx context.Context, t *testing.T, manager *orbital.Manager, jobType string, data []byte) (orbital.Job, error) {
 	t.Helper()
 
-	job := orbital.NewJob(jobType, data)
+	job := orbital.NewJob(jobType, data, uuid.NewString())
 	createdJob, err := manager.PrepareJob(ctx, job)
 	if err != nil {
 		return orbital.Job{}, fmt.Errorf("failed to prepare job: %w", err)

--- a/job.go
+++ b/job.go
@@ -23,6 +23,7 @@ type (
 	// Job is the translated domain object representing an event.
 	Job struct {
 		ID           uuid.UUID
+		ExternalID   string
 		Data         []byte
 		Type         string
 		Status       JobStatus
@@ -36,10 +37,11 @@ type (
 )
 
 // NewJob creates a new Job instance with the given parameters.
-func NewJob(jobType string, data []byte) Job {
+func NewJob(jobType string, data []byte, externalID string) Job {
 	return Job{
-		Data: data,
-		Type: jobType,
+		Type:       jobType,
+		Data:       data,
+		ExternalID: externalID,
 	}
 }
 

--- a/mapper.go
+++ b/mapper.go
@@ -110,6 +110,7 @@ func Encode[T EntityTypes](entityType T) (Entity, error) {
 			CreatedAt: obj.CreatedAt,
 			Values: map[string]any{
 				"id":            obj.ID,
+				"external_id":   obj.ExternalID,
 				"data":          obj.Data,
 				"type":          obj.Type,
 				"status":        obj.Status,
@@ -303,6 +304,9 @@ func decodeJob[T EntityTypes](e Entity) (T, error) {
 	j.ID, j.CreatedAt, j.UpdatedAt = e.ID, e.CreatedAt, e.UpdatedAt
 	vals := e.Values
 	var err error
+	if j.ExternalID, err = resolve[string](vals, "external_id"); err != nil {
+		return empty, err
+	}
 	if j.Type, err = resolve[string](vals, "type"); err != nil {
 		return empty, err
 	}

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -223,6 +223,7 @@ func TestEncodes(t *testing.T) {
 				Data:         []byte("foo-data"),
 				Status:       orbital.JobStatusCreated,
 				Type:         "baz-type",
+				ExternalID:   "external-id",
 			},
 		}
 		expected := []orbital.Entity{
@@ -239,6 +240,7 @@ func TestEncodes(t *testing.T) {
 					"data":          []byte("foo-data"),
 					"status":        orbital.JobStatusCreated,
 					"type":          "baz-type",
+					"external_id":   "external-id",
 				},
 			},
 		}
@@ -659,6 +661,7 @@ func TestDecodeValueVariants(t *testing.T) {
 				"status":        orbital.JobStatusConfirmCanceled,
 				"data":          []byte("x"),
 				"error_message": "error",
+				"external_id":   "external-id",
 			},
 		}
 		job, err := orbital.Decode[orbital.Job](e)
@@ -676,6 +679,7 @@ func TestDecodeValueVariants(t *testing.T) {
 				"status":        "CONFIRMED",
 				"data":          []byte("x"),
 				"error_message": "error",
+				"external_id":   "external-id",
 			},
 		}
 		job, err := orbital.Decode[orbital.Job](e)
@@ -693,6 +697,7 @@ func TestDecodeValueVariants(t *testing.T) {
 				"status":        "CREATED",
 				"data":          nil,
 				"error_message": "error",
+				"external_id":   "external-id",
 			},
 		}
 		job, err := orbital.Decode[orbital.Job](e)
@@ -720,9 +725,10 @@ func TestDecodeValueVariants(t *testing.T) {
 			CreatedAt: now,
 			UpdatedAt: now,
 			Values: map[string]any{
-				"type":   "foo",
-				"status": "CREATED",
-				"data":   "not-bytes",
+				"type":        "foo",
+				"status":      "CREATED",
+				"data":        "not-bytes",
+				"external_id": "external-id",
 			},
 		}
 		_, err := orbital.Decode[orbital.Job](e)
@@ -735,9 +741,10 @@ func TestDecodeValueVariants(t *testing.T) {
 			CreatedAt: now,
 			UpdatedAt: now,
 			Values: map[string]any{
-				"type":   "foo",
-				"status": 10,
-				"data":   "not-bytes",
+				"type":        "foo",
+				"status":      10,
+				"data":        "not-bytes",
+				"external_id": "external-id",
 			},
 		}
 		_, err := orbital.Decode[orbital.Job](e)

--- a/repository_test.go
+++ b/repository_test.go
@@ -518,9 +518,8 @@ func TestRepoTransaction(t *testing.T) {
 	assert.NoError(t, err)
 
 	jobs, err := orbital.ListRepoJobs(repo)(ctx, orbital.ListJobsQuery{
-		Status:    orbital.JobStatusConfirmed,
-		CreatedAt: clock.NowUnixNano(),
-		Limit:     10,
+		Status: orbital.JobStatusConfirmed,
+		Limit:  10,
 	})
 	assert.NoError(t, err)
 	assert.Len(t, jobs, 1)
@@ -546,9 +545,8 @@ func TestRepoTransactionError(t *testing.T) {
 	assert.Equal(t, errTransaction, err)
 
 	jobs, err := orbital.ListRepoJobs(repo)(t.Context(), orbital.ListJobsQuery{
-		Status:    orbital.JobStatusCreated,
-		CreatedAt: clock.NowUnixNano(),
-		Limit:     10,
+		Status: orbital.JobStatusCreated,
+		Limit:  10,
 	})
 	assert.NoError(t, err)
 	assert.Empty(t, jobs)
@@ -606,7 +604,6 @@ func TestRepoTransactionRaceCondition(t *testing.T) {
 				result, err := orbital.ListRepoJobs(&repo)(ctx, orbital.ListJobsQuery{
 					Status:             orbital.JobStatusCreated,
 					RetrievalModeQueue: true,
-					CreatedAt:          clock.NowUnixNano(),
 					Limit:              10,
 				})
 				assert.NoError(t, err)
@@ -629,9 +626,8 @@ func TestRepoTransactionRaceCondition(t *testing.T) {
 
 		// should fetch the updated job for the first transaction
 		jobs, err := orbital.ListRepoJobs(repo)(ctx, orbital.ListJobsQuery{
-			Status:    orbital.JobStatusResolveCanceled,
-			CreatedAt: clock.NowUnixNano(),
-			Limit:     10,
+			Status: orbital.JobStatusResolveCanceled,
+			Limit:  10,
 		})
 		assert.NoError(t, err)
 		assert.Len(t, jobs, 1)
@@ -703,9 +699,8 @@ func TestRepoTransactionRaceCondition(t *testing.T) {
 
 		// should fetch the updated job for the second transaction
 		jobs, err := orbital.ListRepoJobs(repo)(ctx, orbital.ListJobsQuery{
-			Status:    orbital.JobStatusConfirmCanceled,
-			CreatedAt: clock.NowUnixNano(),
-			Limit:     10,
+			Status: orbital.JobStatusConfirmCanceled,
+			Limit:  10,
 		})
 		assert.NoError(t, err)
 		assert.Len(t, jobs, 1)

--- a/store/query/query.go
+++ b/store/query/query.go
@@ -12,6 +12,8 @@ const (
 	operatorIn                                Operator   = "IN"
 	fieldID                                   Field      = "id"
 	fieldJobID                                Field      = "job_id"
+	fieldExternalID                           Field      = "external_id"
+	fieldType                                 Field      = "type"
 	fieldStatus                               Field      = "status"
 	fieldCreatedAt                            Field      = "created_at"
 	fieldUpdatedAt                            Field      = "updated_at"
@@ -84,6 +86,18 @@ func ClauseWithID(id uuid.UUID) Clause {
 // the equality operator and the provided UUID value.
 func ClauseWithJobID(jobID uuid.UUID) Clause {
 	return Clause{Field: fieldJobID, Operator: operatorEqual, Value: jobID}
+}
+
+// ClauseWithExternalID creates a Clause that filters by the external ID field using
+// the equality operator and the provided external ID value.
+func ClauseWithExternalID(externalID string) Clause {
+	return Clause{Field: fieldExternalID, Operator: operatorEqual, Value: externalID}
+}
+
+// ClauseWithType creates a Clause that filters by the type field using
+// the equality operator and the provided type value.
+func ClauseWithType(t string) Clause {
+	return Clause{Field: fieldType, Operator: operatorEqual, Value: t}
 }
 
 // ClauseWithStatus creates a Clause that filters by the status field using

--- a/store/query/query_test.go
+++ b/store/query/query_test.go
@@ -77,6 +77,24 @@ func TestQueryClause(t *testing.T) {
 			},
 		},
 		{
+			name: "should create clause with Type",
+			clauseCreator: func() query.Clause {
+				return query.ClauseWithType("type")
+			},
+			expClause: query.Clause{
+				Field: "type", Operator: query.Operator("="), Value: "type",
+			},
+		},
+		{
+			name: "should create clause with ExternalID",
+			clauseCreator: func() query.Clause {
+				return query.ClauseWithExternalID("external-id")
+			},
+			expClause: query.Clause{
+				Field: "external_id", Operator: query.Operator("="), Value: "external-id",
+			},
+		},
+		{
 			name: "should create clause with ReadyToBeSent",
 			clauseCreator: func() query.Clause {
 				return query.ClauseWithReadyToBeSent(100)

--- a/store/sql/sql.go
+++ b/store/sql/sql.go
@@ -38,6 +38,8 @@ func New(ctx context.Context, db *sql.DB) (*SQL, error) {
    			updated_at BIGINT NOT NULL,
    			created_at BIGINT NOT NULL
    		);
+		ALTER TABLE jobs 
+			ADD COLUMN IF NOT EXISTS external_id VARCHAR(100);
    		CREATE TABLE IF NOT EXISTS tasks(
    			id UUID PRIMARY KEY,
    			job_id UUID NOT NULL,


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       breaking|feat|doc|build|chore|ci|docs|fix|perf|refactor|revert|style|test
- description:   <short description of the PR>

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
- Add a new job field `ExternalID` to allow Orbital users to identify and reference jobs
- Add a `ListJobs` operation to retrieve jobs by their `ExternalID`
- Add a `RunJobOnce` operation that prevents duplicate execution by checking for existing jobs with the same `ExternalID` and `Type`

