### PR TITLE
fix: return error if task is not found in response processing

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -120,6 +120,7 @@ var (
 	ErrNoClientForTarget  = errors.New("no client for task target")
 	ErrLoadingJob         = errors.New("failed to load job")
 	ErrUpdatingJob        = errors.New("failed to update job")
+	ErrTaskNotFound       = errors.New("task not found")
 )
 
 // NewManager creates a new Manager instance.
@@ -700,8 +701,11 @@ func (m *Manager) handleResponses(ctx context.Context, client Initiator, target 
 func (m *Manager) processResponse(ctx context.Context, resp TaskResponse) error {
 	return m.repo.transaction(ctx, func(txCtx context.Context, repo Repository) error {
 		task, found, err := repo.getTaskForUpdate(txCtx, resp.TaskID)
-		if err != nil || !found {
+		if err != nil {
 			return err
+		}
+		if !found {
+			return ErrTaskNotFound
 		}
 		txCtx = slogctx.With(txCtx, "taskID", task.ID, "etag", task.ETag)
 


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       fix
- description:   return error if task is not found in response processing

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
This returns an error when the task specified in the response cannot be found in the repository during task response processing.
