### PR TITLE
feat: add ExternalID to TaskRequest and TaskResponse

### DIFF
--- a/client/embedded/embedded.go
+++ b/client/embedded/embedded.go
@@ -75,6 +75,7 @@ func (c *Client) ReceiveTaskResponse(ctx context.Context) (orbital.TaskResponse,
 		resp.TaskID = req.TaskID
 		resp.ETag = req.ETag
 		resp.Type = req.Type
+		resp.ExternalID = req.ExternalID
 		return resp, err
 	}
 }

--- a/client/embedded/embedded_test.go
+++ b/client/embedded/embedded_test.go
@@ -57,8 +57,9 @@ func TestSendTask_ReceivedTaskResponse(t *testing.T) {
 
 	ctx := t.Context()
 	req := orbital.TaskRequest{
-		TaskID: uuid.New(),
-		ETag:   uuid.New().String(),
+		TaskID:     uuid.New(),
+		ETag:       uuid.New().String(),
+		ExternalID: uuid.New().String(),
 	}
 
 	err = client.SendTaskRequest(ctx, req)
@@ -70,6 +71,7 @@ func TestSendTask_ReceivedTaskResponse(t *testing.T) {
 	assert.Equal(t, req.TaskID, resp.TaskID)
 	assert.Equal(t, req.ETag, resp.ETag)
 	assert.Equal(t, req.Type, resp.Type)
+	assert.Equal(t, req.ExternalID, resp.ExternalID)
 }
 
 func TestOperatorFuncError(t *testing.T) {

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -12,6 +12,7 @@ import (
 var expTaskRequest = orbital.TaskRequest{
 	TaskID:       uuid.New(),
 	Type:         "test",
+	ExternalID:   "external-id",
 	Data:         []byte("test data"),
 	WorkingState: []byte("prev state"),
 	ETag:         "etag",
@@ -20,6 +21,7 @@ var expTaskRequest = orbital.TaskRequest{
 var expTaskResponse = orbital.TaskResponse{
 	TaskID:            uuid.New(),
 	Type:              "test",
+	ExternalID:        "external-id",
 	Status:            string(orbital.ResultDone),
 	WorkingState:      []byte("after state"),
 	ETag:              "etag",
@@ -31,6 +33,7 @@ func assertTaskRequest(t *testing.T, actTaskRequest orbital.TaskRequest) {
 	t.Helper()
 	assert.Equal(t, expTaskRequest.TaskID, actTaskRequest.TaskID)
 	assert.Equal(t, expTaskRequest.Type, actTaskRequest.Type)
+	assert.Equal(t, expTaskRequest.ExternalID, actTaskRequest.ExternalID)
 	assert.Equal(t, expTaskRequest.Data, actTaskRequest.Data)
 	assert.Equal(t, expTaskRequest.WorkingState, actTaskRequest.WorkingState)
 	assert.Equal(t, expTaskRequest.ETag, actTaskRequest.ETag)
@@ -40,6 +43,7 @@ func assertTaskResponse(t *testing.T, actTaskResponse orbital.TaskResponse) {
 	t.Helper()
 	assert.Equal(t, expTaskResponse.TaskID, actTaskResponse.TaskID)
 	assert.Equal(t, expTaskResponse.Type, actTaskResponse.Type)
+	assert.Equal(t, expTaskResponse.ExternalID, actTaskResponse.ExternalID)
 	assert.Equal(t, expTaskResponse.Status, actTaskResponse.Status)
 	assert.Equal(t, expTaskResponse.WorkingState, actTaskResponse.WorkingState)
 	assert.Equal(t, expTaskResponse.ETag, actTaskResponse.ETag)

--- a/codec/proto.go
+++ b/codec/proto.go
@@ -28,6 +28,7 @@ func (p Proto) DecodeTaskRequest(bytes []byte) (orbital.TaskRequest, error) {
 	return orbital.TaskRequest{
 		TaskID:       id,
 		Type:         pReq.GetType(),
+		ExternalID:   pReq.GetExternalId(),
 		WorkingState: pReq.GetWorkingState(),
 		ETag:         pReq.GetEtag(),
 		Data:         pReq.GetData(),
@@ -39,6 +40,7 @@ func (p Proto) EncodeTaskRequest(request orbital.TaskRequest) ([]byte, error) {
 	return proto.Marshal(&orbitalpb.TaskRequest{
 		TaskId:       request.TaskID.String(),
 		Type:         request.Type,
+		ExternalId:   request.ExternalID,
 		WorkingState: request.WorkingState,
 		Etag:         request.ETag,
 		Data:         request.Data,
@@ -60,6 +62,7 @@ func (p Proto) DecodeTaskResponse(bytes []byte) (orbital.TaskResponse, error) {
 	return orbital.TaskResponse{
 		TaskID:            id,
 		Type:              pRes.GetType(),
+		ExternalID:        pRes.GetExternalId(),
 		WorkingState:      pRes.GetWorkingState(),
 		ETag:              pRes.GetEtag(),
 		Status:            pRes.GetStatus().String(),
@@ -73,6 +76,7 @@ func (p Proto) EncodeTaskResponse(response orbital.TaskResponse) ([]byte, error)
 	return proto.Marshal(&orbitalpb.TaskResponse{
 		TaskId:            response.TaskID.String(),
 		Type:              response.Type,
+		ExternalId:        response.ExternalID,
 		WorkingState:      response.WorkingState,
 		Etag:              response.ETag,
 		Status:            orbitalpb.TaskStatus(orbitalpb.TaskStatus_value[response.Status]),

--- a/examples/operator/main.go
+++ b/examples/operator/main.go
@@ -63,10 +63,11 @@ func sendAndReceive() {
 	handleErr("initializing initiator", err)
 
 	req := orbital.TaskRequest{
-		TaskID: uuid.New(),
-		ETag:   "example-etag",
-		Type:   "example",
-		Data:   []byte("example data"),
+		TaskID:     uuid.New(),
+		ETag:       "example-etag",
+		Type:       "example",
+		ExternalID: "example-external-id",
+		Data:       []byte("example data"),
 	}
 
 	reqJSON, err := json.MarshalIndent(req, "", "  ") // will base64 encode the data field

--- a/interactor.go
+++ b/interactor.go
@@ -10,6 +10,7 @@ import (
 type TaskRequest struct {
 	TaskID       uuid.UUID `json:"taskId"`       // TaskID is used to identify the task.
 	Type         string    `json:"type"`         // Type is the type of the task.
+	ExternalID   string    `json:"externalId"`   // External ID serves as an identifier for a Job
 	Data         []byte    `json:"data"`         // Data is the static context for the task.
 	WorkingState []byte    `json:"workingState"` // WorkingState is the current state of the task that the operator works upon.
 	ETag         string    `json:"eTag"`         // ETag is used to identify the version of the TaskRequest.
@@ -19,6 +20,7 @@ type TaskRequest struct {
 type TaskResponse struct {
 	TaskID            uuid.UUID `json:"taskId"`                 // TaskID is used to identify the task.
 	Type              string    `json:"type"`                   // Type is the type of the task.
+	ExternalID        string    `json:"externalId"`             // External ID serves as an identifier for a Job
 	WorkingState      []byte    `json:"workingState"`           // WorkingState is the state of the task that the operator updates.
 	ETag              string    `json:"eTag"`                   // ETag is used to correlate the TaskResponse with the TaskRequest.
 	Status            string    `json:"status"`                 // Status is the status of the task.

--- a/operator.go
+++ b/operator.go
@@ -162,9 +162,10 @@ func (o *Operator) startResponding(ctx context.Context) {
 					return
 				case req := <-o.requests:
 					resp := TaskResponse{
-						TaskID: req.TaskID,
-						Type:   req.Type,
-						ETag:   req.ETag,
+						TaskID:     req.TaskID,
+						Type:       req.Type,
+						ExternalID: req.ExternalID,
+						ETag:       req.ETag,
 					}
 
 					h, ok := o.handlerRegistry.r[req.Type]

--- a/operator_test.go
+++ b/operator_test.go
@@ -158,6 +158,7 @@ func TestListenAndRespond(t *testing.T) {
 	taskReq := orbital.TaskRequest{
 		TaskID:       uuid.New(),
 		Type:         "success",
+		ExternalID:   "external-id",
 		ETag:         "etag",
 		Data:         []byte("test data"),
 		WorkingState: []byte("prev working state"),
@@ -188,6 +189,7 @@ func TestListenAndRespond(t *testing.T) {
 
 	assert.Equal(t, taskReq.TaskID, resp.TaskID)
 	assert.Equal(t, taskReq.Type, resp.Type)
+	assert.Equal(t, taskReq.ExternalID, resp.ExternalID)
 	assert.Equal(t, taskReq.ETag, resp.ETag)
 	assert.Equal(t, expWorkingState, resp.WorkingState)
 	assert.Equal(t, string(expState), resp.Status)

--- a/proto/orbital/v1/task_request.pb.go
+++ b/proto/orbital/v1/task_request.pb.go
@@ -27,6 +27,7 @@ type TaskRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	TaskId        string                 `protobuf:"bytes,10,opt,name=taskId,proto3" json:"taskId,omitempty"`             // UUID as string
 	Type          string                 `protobuf:"bytes,20,opt,name=type,proto3" json:"type,omitempty"`                 // Type of the task
+	ExternalId    string                 `protobuf:"bytes,25,opt,name=externalId,proto3" json:"externalId,omitempty"`     // External ID serves as an identifier for a Job.
 	Data          []byte                 `protobuf:"bytes,30,opt,name=data,proto3,oneof" json:"data,omitempty"`           // Static context for the task
 	WorkingState  []byte                 `protobuf:"bytes,40,opt,name=workingState,proto3" json:"workingState,omitempty"` // Current state of the task
 	Etag          string                 `protobuf:"bytes,50,opt,name=etag,proto3" json:"etag,omitempty"`                 // Versioning tag
@@ -78,6 +79,13 @@ func (x *TaskRequest) GetType() string {
 	return ""
 }
 
+func (x *TaskRequest) GetExternalId() string {
+	if x != nil {
+		return x.ExternalId
+	}
+	return ""
+}
+
 func (x *TaskRequest) GetData() []byte {
 	if x != nil {
 		return x.Data
@@ -104,11 +112,14 @@ var File_orbital_v1_task_request_proto protoreflect.FileDescriptor
 const file_orbital_v1_task_request_proto_rawDesc = "" +
 	"\n" +
 	"\x1dorbital/v1/task_request.proto\x12\n" +
-	"orbital.v1\"\x93\x01\n" +
+	"orbital.v1\"\xb3\x01\n" +
 	"\vTaskRequest\x12\x16\n" +
 	"\x06taskId\x18\n" +
 	" \x01(\tR\x06taskId\x12\x12\n" +
-	"\x04type\x18\x14 \x01(\tR\x04type\x12\x17\n" +
+	"\x04type\x18\x14 \x01(\tR\x04type\x12\x1e\n" +
+	"\n" +
+	"externalId\x18\x19 \x01(\tR\n" +
+	"externalId\x12\x17\n" +
 	"\x04data\x18\x1e \x01(\fH\x00R\x04data\x88\x01\x01\x12\"\n" +
 	"\fworkingState\x18( \x01(\fR\fworkingState\x12\x12\n" +
 	"\x04etag\x182 \x01(\tR\x04etagB\a\n" +

--- a/proto/orbital/v1/task_request.pb.validate.go
+++ b/proto/orbital/v1/task_request.pb.validate.go
@@ -61,6 +61,8 @@ func (m *TaskRequest) validate(all bool) error {
 
 	// no validation rules for Type
 
+	// no validation rules for ExternalId
+
 	// no validation rules for WorkingState
 
 	// no validation rules for Etag

--- a/proto/orbital/v1/task_request.proto
+++ b/proto/orbital/v1/task_request.proto
@@ -6,6 +6,7 @@ package orbital.v1;
 message TaskRequest {
   string taskId = 10; // UUID as string
   string type = 20; // Type of the task
+  string externalId = 25; // External ID serves as an identifier for a Job.
   optional bytes data = 30; // Static context for the task
   bytes workingState = 40; // Current state of the task
   string etag = 50; // Versioning tag

--- a/proto/orbital/v1/task_response.pb.go
+++ b/proto/orbital/v1/task_response.pb.go
@@ -77,6 +77,7 @@ type TaskResponse struct {
 	state             protoimpl.MessageState `protogen:"open.v1"`
 	TaskId            string                 `protobuf:"bytes,10,opt,name=taskId,proto3" json:"taskId,omitempty"`                             // UUID as string
 	Type              string                 `protobuf:"bytes,20,opt,name=type,proto3" json:"type,omitempty"`                                 // Type of the task
+	ExternalId        string                 `protobuf:"bytes,25,opt,name=externalId,proto3" json:"externalId,omitempty"`                     // External ID serves as an identifier for a Job.
 	WorkingState      []byte                 `protobuf:"bytes,30,opt,name=workingState,proto3,oneof" json:"workingState,omitempty"`           // Updated state of the task
 	Etag              string                 `protobuf:"bytes,40,opt,name=etag,proto3" json:"etag,omitempty"`                                 // Correlates with TaskRequest
 	Status            TaskStatus             `protobuf:"varint,50,opt,name=status,proto3,enum=orbital.v1.TaskStatus" json:"status,omitempty"` // Status of the task
@@ -130,6 +131,13 @@ func (x *TaskResponse) GetType() string {
 	return ""
 }
 
+func (x *TaskResponse) GetExternalId() string {
+	if x != nil {
+		return x.ExternalId
+	}
+	return ""
+}
+
 func (x *TaskResponse) GetWorkingState() []byte {
 	if x != nil {
 		return x.WorkingState
@@ -170,11 +178,14 @@ var File_orbital_v1_task_response_proto protoreflect.FileDescriptor
 const file_orbital_v1_task_response_proto_rawDesc = "" +
 	"\n" +
 	"\x1eorbital/v1/task_response.proto\x12\n" +
-	"orbital.v1\"\xa0\x02\n" +
+	"orbital.v1\"\xc0\x02\n" +
 	"\fTaskResponse\x12\x16\n" +
 	"\x06taskId\x18\n" +
 	" \x01(\tR\x06taskId\x12\x12\n" +
-	"\x04type\x18\x14 \x01(\tR\x04type\x12'\n" +
+	"\x04type\x18\x14 \x01(\tR\x04type\x12\x1e\n" +
+	"\n" +
+	"externalId\x18\x19 \x01(\tR\n" +
+	"externalId\x12'\n" +
 	"\fworkingState\x18\x1e \x01(\fH\x00R\fworkingState\x88\x01\x01\x12\x12\n" +
 	"\x04etag\x18( \x01(\tR\x04etag\x12.\n" +
 	"\x06status\x182 \x01(\x0e2\x16.orbital.v1.TaskStatusR\x06status\x12'\n" +

--- a/proto/orbital/v1/task_response.pb.validate.go
+++ b/proto/orbital/v1/task_response.pb.validate.go
@@ -61,6 +61,8 @@ func (m *TaskResponse) validate(all bool) error {
 
 	// no validation rules for Type
 
+	// no validation rules for ExternalId
+
 	// no validation rules for Etag
 
 	// no validation rules for Status

--- a/proto/orbital/v1/task_response.proto
+++ b/proto/orbital/v1/task_response.proto
@@ -13,6 +13,7 @@ enum TaskStatus {
 message TaskResponse {
   string taskId = 10; // UUID as string
   string type = 20; // Type of the task
+  string externalId = 25; // External ID serves as an identifier for a Job.
   optional bytes workingState = 30; // Updated state of the task
   string etag = 40; // Correlates with TaskRequest
   TaskStatus status = 50; // Status of the task

--- a/reconcile_test.go
+++ b/reconcile_test.go
@@ -171,6 +171,7 @@ func TestReconcile(t *testing.T) {
 		client, err := embedded.NewClient(func(_ context.Context, req orbital.TaskRequest) (orbital.TaskResponse, error) {
 			assert.Equal(t, ids[0], req.TaskID)
 			assert.Equal(t, expType, req.Type)
+			assert.Equal(t, job.ExternalID, req.ExternalID)
 			assert.Equal(t, expData, req.Data)
 			assert.Equal(t, expWorkingState, req.WorkingState)
 			assert.Equal(t, expETag, req.ETag)


### PR DESCRIPTION
This change introduces the ExternalID field to both TaskRequest and TaskResponse structs, as well as their corresponding protobuf messages. ExternalID serves as an identifier for a Job, allowing for better correlation and tracking of tasks and responses. All relevant code, tests, and protobuf files have been updated to support this new field.

<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       breaking|feat|doc|build|chore|ci|docs|fix|perf|refactor|revert|style|test
- description:   <short description of the PR>

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
``` Detailed description of PR; If no description, remove the block.

```

**Special notes for your reviewer**:
``` If no notes, remove the block.

```

**Release note**:
``` Release notes; If no release note is required, just write "NONE" within the block.

```
