### PR TITLE
feat: prepare and get job groups

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -111,18 +111,6 @@ func ToCanonicalData[T TaskRequest | TaskResponse](in T) ([]byte, error) {
 	return toCanonicalData(in)
 }
 
-func CreateRepoJobGroup(r *Repository) func(ctx context.Context, jg JobGroup) (JobGroup, error) {
-	return r.createJobGroup
-}
-
-func GetRepoJobGroup(r *Repository) func(ctx context.Context, id uuid.UUID) (JobGroup, bool, error) {
-	return r.getJobGroup
-}
-
-func ListRepoJobsByGroupID(r *Repository) func(ctx context.Context, groupID uuid.UUID) ([]Job, error) {
-	return r.listJobsByGroupID
-}
-
 var (
 	ResolveLabels        = resolveLabels
 	MergeLabels          = mergeLabels

--- a/export_test.go
+++ b/export_test.go
@@ -111,6 +111,20 @@ func ToCanonicalData[T TaskRequest | TaskResponse](in T) ([]byte, error) {
 	return toCanonicalData(in)
 }
 
-func ResolveLabels(values map[string]any, key string) (Labels, error) {
-	return resolveLabels(values, key)
+func CreateRepoJobGroup(r *Repository) func(ctx context.Context, jg JobGroup) (JobGroup, error) {
+	return r.createJobGroup
 }
+
+func GetRepoJobGroup(r *Repository) func(ctx context.Context, id uuid.UUID) (JobGroup, bool, error) {
+	return r.getJobGroup
+}
+
+func ListRepoJobsByGroupID(r *Repository) func(ctx context.Context, groupID uuid.UUID) ([]Job, error) {
+	return r.listJobsByGroupID
+}
+
+var (
+	ResolveLabels        = resolveLabels
+	MergeLabels          = mergeLabels
+	SortJobsByGroupOrder = sortJobsByGroupOrder
+)

--- a/helper_test.go
+++ b/helper_test.go
@@ -67,6 +67,7 @@ func clearTables(t *testing.T, db *stdsql.DB) {
 	assert.NoError(t, clearTasksTable(ctx, db))
 	assert.NoError(t, clearJobCursorTable(ctx, db))
 	assert.NoError(t, clearJobEventTable(ctx, db))
+	assert.NoError(t, clearJobGroupsTable(ctx, db))
 }
 
 func clearJobTable(ctx context.Context, db *stdsql.DB) error {
@@ -86,6 +87,11 @@ func clearJobCursorTable(ctx context.Context, db *stdsql.DB) error {
 
 func clearJobEventTable(ctx context.Context, db *stdsql.DB) error {
 	_, err := db.ExecContext(ctx, "DELETE FROM job_event")
+	return err
+}
+
+func clearJobGroupsTable(ctx context.Context, db *stdsql.DB) error {
+	_, err := db.ExecContext(ctx, "DELETE FROM job_groups")
 	return err
 }
 

--- a/job.go
+++ b/job.go
@@ -6,6 +6,7 @@ import (
 
 // Possible job statuses.
 const (
+	JobStatusScheduled       JobStatus = "SCHEDULED"
 	JobStatusCreated         JobStatus = "CREATED"
 	JobStatusConfirming      JobStatus = "CONFIRMING"
 	JobStatusConfirmed       JobStatus = "CONFIRMED"
@@ -17,6 +18,14 @@ const (
 	JobStatusResolveCanceled JobStatus = "RESOLVE_CANCELED"
 	JobStatusConfirmCanceled JobStatus = "CONFIRM_CANCELED"
 	JobStatusUserCanceled    JobStatus = "USER_CANCELED"
+)
+
+// Reserved label keys for job group functionality.
+const (
+	// LabelKeyGroupID is the label key for storing the parent group's UUID.
+	LabelKeyGroupID = "orbital/group-id"
+	// LabelKeyGroupOrderKey is the label key for storing the job's position within the group.
+	LabelKeyGroupOrderKey = "orbital/group-order-key"
 )
 
 type (

--- a/jobgroup.go
+++ b/jobgroup.go
@@ -1,6 +1,12 @@
 package orbital
 
-import "github.com/google/uuid"
+import (
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/google/uuid"
+)
 
 // Possible group statuses.
 const (
@@ -16,7 +22,7 @@ type (
 	JobGroup struct {
 		ID           uuid.UUID
 		Type         string
-		Jobs         []Job // Ordered list of jobs
+		Jobs         []Job // Jobs in the group, ordered by their position
 		CreatedAt    int64
 		UpdatedAt    int64
 		Status       GroupStatus
@@ -41,4 +47,22 @@ func NewJobGroup(groupType string, jobs ...Job) JobGroup {
 func (jg JobGroup) WithLabels(labels Labels) JobGroup {
 	jg.Labels = labels
 	return jg
+}
+
+// sortJobsByGroupOrder sorts jobs in-place by their group order key (ascending).
+// Returns an error if any job has an invalid or missing order key.
+func sortJobsByGroupOrder(jobs []Job) error {
+	for _, job := range jobs {
+		if _, err := strconv.Atoi(job.Labels[LabelKeyGroupOrderKey]); err != nil {
+			return fmt.Errorf("job %s has invalid or missing group order key: %w", job.ID, err)
+		}
+	}
+
+	sort.Slice(jobs, func(i, j int) bool {
+		orderI, _ := strconv.Atoi(jobs[i].Labels[LabelKeyGroupOrderKey])
+		orderJ, _ := strconv.Atoi(jobs[j].Labels[LabelKeyGroupOrderKey])
+		return orderI < orderJ
+	})
+
+	return nil
 }

--- a/jobgroup_test.go
+++ b/jobgroup_test.go
@@ -163,3 +163,87 @@ func TestGroupStatus(t *testing.T) {
 		assert.Len(t, seen, 5)
 	})
 }
+
+func TestSortJobsByGroupOrder(t *testing.T) {
+	tests := []struct {
+		name     string
+		jobs     []orbital.Job
+		expOrder []string
+		expErr   string
+	}{
+		{
+			name: "should sort jobs by order key ascending",
+			jobs: []orbital.Job{
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "2"}},
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "0"}},
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "1"}},
+			},
+			expOrder: []string{"0", "1", "2"},
+		},
+		{
+			name:     "should handle empty slice",
+			jobs:     []orbital.Job{},
+			expOrder: []string{},
+		},
+		{
+			name: "should handle single job",
+			jobs: []orbital.Job{
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "5"}},
+			},
+			expOrder: []string{"5"},
+		},
+		{
+			name: "should return error when order key is missing",
+			jobs: []orbital.Job{
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "0"}},
+				{ID: uuid.New(), Labels: orbital.Labels{"other": "label"}},
+			},
+			expErr: "invalid or missing group order key",
+		},
+		{
+			name: "should return error when order key is not a number",
+			jobs: []orbital.Job{
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "0"}},
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "abc"}},
+			},
+			expErr: "invalid or missing group order key",
+		},
+		{
+			name: "should return error when labels are nil",
+			jobs: []orbital.Job{
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "0"}},
+				{ID: uuid.New(), Labels: nil},
+			},
+			expErr: "invalid or missing group order key",
+		},
+		{
+			name: "should sort jobs with large order keys",
+			jobs: []orbital.Job{
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "100"}},
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "10"}},
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "1"}},
+			},
+			expOrder: []string{"1", "10", "100"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// when
+			err := orbital.SortJobsByGroupOrder(tt.jobs)
+
+			// then
+			if tt.expErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expErr)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Len(t, tt.jobs, len(tt.expOrder))
+			for i, expKey := range tt.expOrder {
+				assert.Equal(t, expKey, tt.jobs[i].Labels[orbital.LabelKeyGroupOrderKey])
+			}
+		})
+	}
+}

--- a/labels.go
+++ b/labels.go
@@ -1,8 +1,10 @@
 package orbital
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 )
 
@@ -24,4 +26,20 @@ func (l Labels) Validate() error {
 		}
 	}
 	return nil
+}
+
+// ToJSON converts Labels to JSON bytes for storage.
+func (l Labels) ToJSON() ([]byte, error) {
+	return json.Marshal(l)
+}
+
+// mergeLabels creates a new Labels map by merging multiple label maps.
+// Later maps override earlier maps if keys conflict.
+// No input maps are modified. Nil maps are skipped.
+func mergeLabels(labelMaps ...Labels) Labels {
+	merged := make(Labels)
+	for _, labels := range labelMaps {
+		maps.Copy(merged, labels)
+	}
+	return merged
 }

--- a/labels.go
+++ b/labels.go
@@ -36,10 +36,10 @@ func (l Labels) ToJSON() ([]byte, error) {
 // mergeLabels creates a new Labels map by merging multiple label maps.
 // Later maps override earlier maps if keys conflict.
 // No input maps are modified. Nil maps are skipped.
-func mergeLabels(labelMaps ...Labels) Labels {
+func mergeLabels(ls ...Labels) Labels {
 	merged := make(Labels)
-	for _, labels := range labelMaps {
-		maps.Copy(merged, labels)
+	for _, l := range ls {
+		maps.Copy(merged, l)
 	}
 	return merged
 }

--- a/labels_test.go
+++ b/labels_test.go
@@ -156,7 +156,7 @@ func TestMergeLabels(t *testing.T) {
 		assert.Empty(t, result)
 	})
 
-	t.Run("should merge single labels map", func(t *testing.T) {
+	t.Run("should merge single label", func(t *testing.T) {
 		// given
 		labels := orbital.Labels{"tenant": "acme", "env": "prod"}
 
@@ -169,7 +169,7 @@ func TestMergeLabels(t *testing.T) {
 		assert.Len(t, result, 2)
 	})
 
-	t.Run("should merge multiple labels maps", func(t *testing.T) {
+	t.Run("should merge multiple labels", func(t *testing.T) {
 		// given
 		labels1 := orbital.Labels{"tenant": "acme"}
 		labels2 := orbital.Labels{"env": "prod"}
@@ -185,7 +185,7 @@ func TestMergeLabels(t *testing.T) {
 		assert.Len(t, result, 3)
 	})
 
-	t.Run("should override with later maps", func(t *testing.T) {
+	t.Run("should override with later label", func(t *testing.T) {
 		// given
 		labels1 := orbital.Labels{"key": "first", "other": "value"}
 		labels2 := orbital.Labels{"key": "second"}
@@ -199,7 +199,7 @@ func TestMergeLabels(t *testing.T) {
 		assert.Len(t, result, 2)
 	})
 
-	t.Run("should not modify original labels", func(t *testing.T) {
+	t.Run("should not modify original label", func(t *testing.T) {
 		// given
 		labels1 := orbital.Labels{"tenant": "acme"}
 		labels2 := orbital.Labels{"env": "prod"}
@@ -213,7 +213,7 @@ func TestMergeLabels(t *testing.T) {
 		assert.Len(t, result, 2)  // New map has 2 entries
 	})
 
-	t.Run("should skip nil maps in variadic args", func(t *testing.T) {
+	t.Run("should skip nil labels in variadic args", func(t *testing.T) {
 		// given
 		labels := orbital.Labels{"tenant": "acme"}
 
@@ -225,7 +225,7 @@ func TestMergeLabels(t *testing.T) {
 		assert.Len(t, result, 1)
 	})
 
-	t.Run("should handle empty maps", func(t *testing.T) {
+	t.Run("should handle empty labels", func(t *testing.T) {
 		// given
 		labels1 := orbital.Labels{}
 		labels2 := orbital.Labels{"tenant": "acme"}

--- a/labels_test.go
+++ b/labels_test.go
@@ -142,4 +142,134 @@ func TestJob_WithLabels(t *testing.T) {
 
 func TestLabelConstants(t *testing.T) {
 	assert.Equal(t, "orbital/", orbital.LabelPrefixReserved)
+	assert.Equal(t, "orbital/group-id", orbital.LabelKeyGroupID)
+	assert.Equal(t, "orbital/group-order-key", orbital.LabelKeyGroupOrderKey)
+}
+
+func TestMergeLabels(t *testing.T) {
+	t.Run("should merge nil labels", func(t *testing.T) {
+		// when
+		result := orbital.MergeLabels(nil)
+
+		// then
+		assert.NotNil(t, result)
+		assert.Empty(t, result)
+	})
+
+	t.Run("should merge single labels map", func(t *testing.T) {
+		// given
+		labels := orbital.Labels{"tenant": "acme", "env": "prod"}
+
+		// when
+		result := orbital.MergeLabels(labels)
+
+		// then
+		assert.Equal(t, "acme", result["tenant"])
+		assert.Equal(t, "prod", result["env"])
+		assert.Len(t, result, 2)
+	})
+
+	t.Run("should merge multiple labels maps", func(t *testing.T) {
+		// given
+		labels1 := orbital.Labels{"tenant": "acme"}
+		labels2 := orbital.Labels{"env": "prod"}
+		labels3 := orbital.Labels{"priority": "high"}
+
+		// when
+		result := orbital.MergeLabels(labels1, labels2, labels3)
+
+		// then
+		assert.Equal(t, "acme", result["tenant"])
+		assert.Equal(t, "prod", result["env"])
+		assert.Equal(t, "high", result["priority"])
+		assert.Len(t, result, 3)
+	})
+
+	t.Run("should override with later maps", func(t *testing.T) {
+		// given
+		labels1 := orbital.Labels{"key": "first", "other": "value"}
+		labels2 := orbital.Labels{"key": "second"}
+
+		// when
+		result := orbital.MergeLabels(labels1, labels2)
+
+		// then
+		assert.Equal(t, "second", result["key"])  // Overridden
+		assert.Equal(t, "value", result["other"]) // Kept from first
+		assert.Len(t, result, 2)
+	})
+
+	t.Run("should not modify original labels", func(t *testing.T) {
+		// given
+		labels1 := orbital.Labels{"tenant": "acme"}
+		labels2 := orbital.Labels{"env": "prod"}
+
+		// when
+		result := orbital.MergeLabels(labels1, labels2)
+
+		// then
+		assert.Len(t, labels1, 1) // Original unchanged
+		assert.Len(t, labels2, 1) // Original unchanged
+		assert.Len(t, result, 2)  // New map has 2 entries
+	})
+
+	t.Run("should skip nil maps in variadic args", func(t *testing.T) {
+		// given
+		labels := orbital.Labels{"tenant": "acme"}
+
+		// when
+		result := orbital.MergeLabels(nil, labels, nil)
+
+		// then
+		assert.Equal(t, "acme", result["tenant"])
+		assert.Len(t, result, 1)
+	})
+
+	t.Run("should handle empty maps", func(t *testing.T) {
+		// given
+		labels1 := orbital.Labels{}
+		labels2 := orbital.Labels{"tenant": "acme"}
+
+		// when
+		result := orbital.MergeLabels(labels1, labels2)
+
+		// then
+		assert.Equal(t, "acme", result["tenant"])
+		assert.Len(t, result, 1)
+	})
+}
+
+func TestLabels_ToJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   orbital.Labels
+		expected string
+	}{
+		{
+			name:     "nil labels",
+			labels:   nil,
+			expected: "null",
+		},
+		{
+			name:     "empty labels",
+			labels:   orbital.Labels{},
+			expected: "{}",
+		},
+		{
+			name:     "single label",
+			labels:   orbital.Labels{"tenant": "acme"},
+			expected: `{"tenant":"acme"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// when
+			result, err := tt.labels.ToJSON()
+
+			// then
+			assert.NoError(t, err)
+			assert.JSONEq(t, tt.expected, string(result))
+		})
+	}
 }

--- a/manager.go
+++ b/manager.go
@@ -393,6 +393,8 @@ func (m *Manager) PrepareJobGroup(ctx context.Context, group JobGroup) (JobGroup
 }
 
 // GetJobGroup retrieves a job group by its ID along with all its jobs.
+// Returns (group, true, nil) if found, or (empty, false, nil) if not found.
+// Returns an error if a repository or sorting operation fails.
 func (m *Manager) GetJobGroup(ctx context.Context, groupID uuid.UUID) (JobGroup, bool, error) {
 	group, found, err := m.repo.getJobGroup(ctx, groupID)
 	if err != nil {

--- a/manager.go
+++ b/manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -100,6 +101,7 @@ var (
 	ErrLoadingJob              = errors.New("failed to load job")
 	ErrUpdatingJob             = errors.New("failed to update job")
 	ErrTaskNotFound            = errors.New("task not found")
+	ErrJobGroupEmpty           = errors.New("at least one job is required")
 )
 
 // NewManager creates a new Manager instance.
@@ -334,6 +336,91 @@ func (m *Manager) CancelJob(ctx context.Context, jobID uuid.UUID) error {
 
 		return nil
 	})
+}
+
+// PrepareJobGroup creates a job group and all its jobs in a single transaction.
+// All jobs are created with SCHEDULED status and the group is created with CREATED status.
+// Returns an error if no jobs are provided or if any labels validation fails.
+//
+//nolint:cyclop // validation logic and transaction require multiple checks
+func (m *Manager) PrepareJobGroup(ctx context.Context, group JobGroup) (JobGroup, error) {
+	if len(group.Jobs) == 0 {
+		return JobGroup{}, ErrJobGroupEmpty
+	}
+
+	if group.Labels != nil {
+		if err := group.Labels.Validate(); err != nil {
+			return JobGroup{}, err
+		}
+	}
+
+	for _, job := range group.Jobs {
+		if job.Labels != nil {
+			if err := job.Labels.Validate(); err != nil {
+				return JobGroup{}, err
+			}
+		}
+	}
+
+	group.ID = uuid.New()
+	group.Status = GroupStatusCreated
+
+	var err error
+	err = m.repo.transaction(ctx, func(ctx context.Context, repo Repository) error {
+		group, err = repo.createJobGroup(ctx, group)
+		if err != nil {
+			return err
+		}
+
+		jobs := make([]Job, 0, len(group.Jobs))
+		for i, job := range group.Jobs {
+			job.Labels = mergeLabels(job.Labels, Labels{
+				LabelKeyGroupID:       group.ID.String(),
+				LabelKeyGroupOrderKey: strconv.Itoa(i),
+			})
+			job.Status = JobStatusScheduled
+
+			createdJob, err := repo.createJob(ctx, job)
+			if err != nil {
+				return err
+			}
+			jobs = append(jobs, createdJob)
+		}
+		group.Jobs = jobs
+
+		return nil
+	})
+
+	if err != nil {
+		return JobGroup{}, err
+	}
+
+	slogctx.Debug(ctx, "new job group prepared", "jobGroupId", group.ID, "type", group.Type, "jobCount", len(group.Jobs))
+	return group, nil
+}
+
+// GetJobGroup retrieves a job group by its ID along with all its jobs.
+func (m *Manager) GetJobGroup(ctx context.Context, groupID uuid.UUID) (JobGroup, bool, error) {
+	group, found, err := m.repo.getJobGroup(ctx, groupID)
+	if err != nil {
+		return JobGroup{}, false, err
+	}
+	if !found {
+		return JobGroup{}, false, nil
+	}
+
+	jobs, err := m.repo.listJobsByGroupID(ctx, groupID)
+	if err != nil {
+		return JobGroup{}, false, err
+	}
+
+	if err := sortJobsByGroupOrder(jobs); err != nil {
+		return JobGroup{}, false, err
+	}
+
+	group.Jobs = jobs
+
+	return group, true, nil
 }
 
 // confirmJob processes jobs in the CREATED state that were created before a specified delay

--- a/manager.go
+++ b/manager.go
@@ -101,7 +101,7 @@ var (
 	ErrLoadingJob              = errors.New("failed to load job")
 	ErrUpdatingJob             = errors.New("failed to update job")
 	ErrTaskNotFound            = errors.New("task not found")
-	ErrJobGroupEmpty           = errors.New("at least one job is required")
+	ErrJobGroupEmpty           = errors.New("job group must not be empty")
 )
 
 // NewManager creates a new Manager instance.
@@ -284,11 +284,10 @@ func (m *Manager) Stop(ctx context.Context) error {
 // It validates the job labels before creating the job.
 // It returns an error if a job with the same type and external ID in a non-terminal status already exists.
 func (m *Manager) PrepareJob(ctx context.Context, job Job) (Job, error) {
-	if job.Labels != nil {
-		if err := job.Labels.Validate(); err != nil {
-			return Job{}, err
-		}
+	if err := job.Labels.Validate(); err != nil {
+		return Job{}, err
 	}
+
 	job.Status = JobStatusCreated
 	job, err := m.repo.createJob(ctx, job)
 	if err != nil {
@@ -341,24 +340,18 @@ func (m *Manager) CancelJob(ctx context.Context, jobID uuid.UUID) error {
 // PrepareJobGroup creates a job group and all its jobs in a single transaction.
 // All jobs are created with SCHEDULED status and the group is created with CREATED status.
 // Returns an error if no jobs are provided or if any labels validation fails.
-//
-//nolint:cyclop // validation logic and transaction require multiple checks
 func (m *Manager) PrepareJobGroup(ctx context.Context, group JobGroup) (JobGroup, error) {
 	if len(group.Jobs) == 0 {
 		return JobGroup{}, ErrJobGroupEmpty
 	}
 
-	if group.Labels != nil {
-		if err := group.Labels.Validate(); err != nil {
-			return JobGroup{}, err
-		}
+	if err := group.Labels.Validate(); err != nil {
+		return JobGroup{}, err
 	}
 
 	for _, job := range group.Jobs {
-		if job.Labels != nil {
-			if err := job.Labels.Validate(); err != nil {
-				return JobGroup{}, err
-			}
+		if err := job.Labels.Validate(); err != nil {
+			return JobGroup{}, err
 		}
 	}
 

--- a/manager.go
+++ b/manager.go
@@ -362,8 +362,8 @@ func (m *Manager) PrepareJobGroup(ctx context.Context, group JobGroup) (JobGroup
 		}
 	}
 
-	group.ID = uuid.New()
 	group.Status = GroupStatusCreated
+	jobs := group.Jobs
 
 	var err error
 	err = m.repo.transaction(ctx, func(ctx context.Context, repo Repository) error {
@@ -372,8 +372,8 @@ func (m *Manager) PrepareJobGroup(ctx context.Context, group JobGroup) (JobGroup
 			return err
 		}
 
-		jobs := make([]Job, 0, len(group.Jobs))
-		for i, job := range group.Jobs {
+		createdJobs := make([]Job, 0, len(jobs))
+		for i, job := range jobs {
 			job.Labels = mergeLabels(job.Labels, Labels{
 				LabelKeyGroupID:       group.ID.String(),
 				LabelKeyGroupOrderKey: strconv.Itoa(i),
@@ -384,9 +384,9 @@ func (m *Manager) PrepareJobGroup(ctx context.Context, group JobGroup) (JobGroup
 			if err != nil {
 				return err
 			}
-			jobs = append(jobs, createdJob)
+			createdJobs = append(createdJobs, createdJob)
 		}
-		group.Jobs = jobs
+		group.Jobs = createdJobs
 
 		return nil
 	})

--- a/manager_test.go
+++ b/manager_test.go
@@ -1613,6 +1613,8 @@ func TestPrepareJobGroup(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.NotEqual(t, uuid.Nil, result.ID)
+			assert.NotZero(t, result.CreatedAt)
+			assert.NotZero(t, result.UpdatedAt)
 			assert.Equal(t, tt.expGroup.Type, result.Type)
 			assert.Equal(t, tt.expGroup.Status, result.Status)
 			assert.Equal(t, tt.expGroup.Labels, result.Labels)
@@ -1620,6 +1622,8 @@ func TestPrepareJobGroup(t *testing.T) {
 			assert.Len(t, result.Jobs, len(tt.expGroup.Jobs))
 			for i, job := range result.Jobs {
 				assert.NotEqual(t, uuid.Nil, job.ID)
+				assert.NotZero(t, job.CreatedAt)
+				assert.NotZero(t, job.UpdatedAt)
 				assert.Equal(t, tt.expGroup.Jobs[i].Type, job.Type)
 				assert.Equal(t, tt.expGroup.Jobs[i].Status, job.Status)
 				assert.Equal(t, result.ID.String(), job.Labels[orbital.LabelKeyGroupID])

--- a/manager_test.go
+++ b/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1506,6 +1507,194 @@ func TestManagerStop_GracefulShutdown(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, int32(3), closeCallCount.Load())
+	})
+}
+
+func TestPrepareJobGroup(t *testing.T) {
+	tests := []struct {
+		name     string
+		group    orbital.JobGroup
+		expGroup orbital.JobGroup
+		expErr   error
+	}{
+		{
+			name: "should create job group with jobs in correct order",
+			group: orbital.JobGroup{
+				Type:   "batch-sync",
+				Labels: orbital.Labels{"env": "prod"},
+				Jobs: []orbital.Job{
+					{Type: "job-type", Data: []byte("job-1")},
+					{Type: "job-type", Data: []byte("job-2")},
+					{Type: "job-type", Data: []byte("job-3")},
+				},
+			},
+			expGroup: orbital.JobGroup{
+				Type:   "batch-sync",
+				Status: orbital.GroupStatusCreated,
+				Labels: orbital.Labels{"env": "prod"},
+				Jobs: []orbital.Job{
+					{Type: "job-type", Status: orbital.JobStatusScheduled},
+					{Type: "job-type", Status: orbital.JobStatusScheduled},
+					{Type: "job-type", Status: orbital.JobStatusScheduled},
+				},
+			},
+			expErr: nil,
+		},
+		{
+			name: "should merge user labels with group labels on jobs",
+			group: orbital.JobGroup{
+				Type: "batch-sync",
+				Jobs: []orbital.Job{
+					{Type: "job-type", Data: []byte("job-1"), Labels: orbital.Labels{"user-key": "user-value"}},
+				},
+			},
+			expGroup: orbital.JobGroup{
+				Type:   "batch-sync",
+				Status: orbital.GroupStatusCreated,
+				Jobs: []orbital.Job{
+					{Type: "job-type", Status: orbital.JobStatusScheduled, Labels: orbital.Labels{"user-key": "user-value"}},
+				},
+			},
+			expErr: nil,
+		},
+		{
+			name: "should return error when no jobs provided",
+			group: orbital.JobGroup{
+				Type: "batch-sync",
+				Jobs: []orbital.Job{},
+			},
+			expErr: orbital.ErrJobGroupEmpty,
+		},
+		{
+			name: "should return error when group labels have reserved prefix",
+			group: orbital.JobGroup{
+				Type:   "batch-sync",
+				Labels: orbital.Labels{"orbital/custom": "value"},
+				Jobs: []orbital.Job{
+					{Type: "job-type", Data: []byte("job-1")},
+				},
+			},
+			expErr: orbital.ErrReservedLabelPrefix,
+		},
+		{
+			name: "should return error when job labels have reserved prefix",
+			group: orbital.JobGroup{
+				Type: "batch-sync",
+				Jobs: []orbital.Job{
+					{Type: "job-type", Data: []byte("job-1"), Labels: orbital.Labels{"orbital/custom": "value"}},
+				},
+			},
+			expErr: orbital.ErrReservedLabelPrefix,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// given
+			db, store := createSQLStore(t)
+			defer clearTables(t, db)
+			repo := orbital.NewRepository(store)
+
+			subj, err := orbital.NewManager(repo, mockTaskResolveFunc())
+			assert.NoError(t, err)
+
+			ctx := t.Context()
+
+			// when
+			result, err := subj.PrepareJobGroup(ctx, tt.group)
+
+			// then
+			if tt.expErr != nil {
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, tt.expErr)
+				assert.Equal(t, uuid.Nil, result.ID)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotEqual(t, uuid.Nil, result.ID)
+			assert.Equal(t, tt.expGroup.Type, result.Type)
+			assert.Equal(t, tt.expGroup.Status, result.Status)
+			assert.Equal(t, tt.expGroup.Labels, result.Labels)
+
+			assert.Len(t, result.Jobs, len(tt.expGroup.Jobs))
+			for i, job := range result.Jobs {
+				assert.NotEqual(t, uuid.Nil, job.ID)
+				assert.Equal(t, tt.expGroup.Jobs[i].Type, job.Type)
+				assert.Equal(t, tt.expGroup.Jobs[i].Status, job.Status)
+				assert.Equal(t, result.ID.String(), job.Labels[orbital.LabelKeyGroupID])
+				assert.Equal(t, strconv.Itoa(i), job.Labels[orbital.LabelKeyGroupOrderKey])
+				// verify user-provided labels are preserved
+				for k, v := range tt.expGroup.Jobs[i].Labels {
+					assert.Equal(t, v, job.Labels[k])
+				}
+			}
+		})
+	}
+}
+
+func TestGetJobGroup(t *testing.T) {
+	t.Run("should return job group with jobs in correct order", func(t *testing.T) {
+		// given
+		db, store := createSQLStore(t)
+		defer clearTables(t, db)
+		repo := orbital.NewRepository(store)
+
+		subj, err := orbital.NewManager(repo, mockTaskResolveFunc())
+		assert.NoError(t, err)
+
+		ctx := t.Context()
+
+		// Create a job group
+		group := orbital.JobGroup{
+			Type:   "batch-sync",
+			Labels: orbital.Labels{"env": "prod"},
+			Jobs: []orbital.Job{
+				{Type: "job-type", Data: []byte("job-1")},
+				{Type: "job-type", Data: []byte("job-2")},
+				{Type: "job-type", Data: []byte("job-3")},
+			},
+		}
+
+		created, err := subj.PrepareJobGroup(ctx, group)
+		assert.NoError(t, err)
+
+		// when
+		result, found, err := subj.GetJobGroup(ctx, created.ID)
+
+		// then
+		assert.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, created.ID, result.ID)
+		assert.Equal(t, "batch-sync", result.Type)
+		assert.Equal(t, orbital.GroupStatusCreated, result.Status)
+		assert.Equal(t, orbital.Labels{"env": "prod"}, result.Labels)
+
+		assert.Len(t, result.Jobs, 3)
+		for i, job := range result.Jobs {
+			assert.Equal(t, strconv.Itoa(i), job.Labels[orbital.LabelKeyGroupOrderKey])
+			assert.Equal(t, created.Jobs[i].ID, job.ID)
+		}
+	})
+
+	t.Run("should return not found for non-existent group", func(t *testing.T) {
+		// given
+		db, store := createSQLStore(t)
+		defer clearTables(t, db)
+		repo := orbital.NewRepository(store)
+
+		subj, err := orbital.NewManager(repo, mockTaskResolveFunc())
+		assert.NoError(t, err)
+
+		ctx := t.Context()
+
+		// when
+		result, found, err := subj.GetJobGroup(ctx, uuid.New())
+
+		// then
+		assert.NoError(t, err)
+		assert.False(t, found)
+		assert.Equal(t, uuid.Nil, result.ID)
 	})
 }
 

--- a/mapper.go
+++ b/mapper.go
@@ -19,7 +19,7 @@ var (
 
 // TransformToEntities transforms a list of maps into domain entities based on the provided entity name.
 func TransformToEntities(entityName query.EntityName, objs ...map[string]any) ([]Entity, error) {
-	if _, ok := query.SupportedEntityNames[entityName]; !ok {
+	if _, ok := query.ValidEntityNames[entityName]; !ok {
 		return nil, fmt.Errorf("%w `%s` not supported", ErrInvalidEntityType, entityName)
 	}
 

--- a/mapper.go
+++ b/mapper.go
@@ -19,20 +19,19 @@ var (
 
 // TransformToEntities transforms a list of maps into domain entities based on the provided entity name.
 func TransformToEntities(entityName query.EntityName, objs ...map[string]any) ([]Entity, error) {
-	switch entityName {
-	case query.EntityNameJobs, query.EntityNameTasks, query.EntityNameJobCursor, query.EntityNameJobEvent:
-		result := make([]Entity, 0, len(objs))
-		for _, r := range objs {
-			entity, err := TransformToEntity(entityName, r)
-			if err != nil {
-				return nil, err
-			}
-			result = append(result, entity)
-		}
-		return result, nil
-	default:
+	if _, ok := query.SupportedEntityNames[entityName]; !ok {
 		return nil, fmt.Errorf("%w `%s` not supported", ErrInvalidEntityType, entityName)
 	}
+
+	result := make([]Entity, 0, len(objs))
+	for _, r := range objs {
+		entity, err := TransformToEntity(entityName, r)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, entity)
+	}
+	return result, nil
 }
 
 // TransformToEntity transforms a map into a domain entity based on the provided entity name.
@@ -114,13 +113,9 @@ func Encodes[T EntityTypes](entityTypes ...T) ([]Entity, error) {
 func Encode[T EntityTypes](entityType T) (Entity, error) {
 	switch obj := any(entityType).(type) {
 	case Job:
-		var labelsJSON []byte
-		if obj.Labels != nil {
-			var err error
-			labelsJSON, err = json.Marshal(obj.Labels)
-			if err != nil {
-				return Entity{}, err
-			}
+		labelsJSON, err := obj.Labels.ToJSON()
+		if err != nil {
+			return Entity{}, err
 		}
 		return Entity{
 			Name:      query.EntityNameJobs,
@@ -190,6 +185,26 @@ func Encode[T EntityTypes](entityType T) (Entity, error) {
 				"created_at":  obj.CreatedAt,
 			},
 		}, nil
+	case JobGroup:
+		labelsJSON, err := obj.Labels.ToJSON()
+		if err != nil {
+			return Entity{}, err
+		}
+		return Entity{
+			Name:      query.EntityNameJobGroups,
+			ID:        obj.ID,
+			UpdatedAt: obj.UpdatedAt,
+			CreatedAt: obj.CreatedAt,
+			Values: map[string]any{
+				"id":            obj.ID,
+				"type":          obj.Type,
+				"status":        obj.Status,
+				"error_message": obj.ErrorMessage,
+				"updated_at":    obj.UpdatedAt,
+				"created_at":    obj.CreatedAt,
+				"labels":        labelsJSON,
+			},
+		}, nil
 	default:
 		return Entity{}, fmt.Errorf("%w `%T` not supported", ErrInvalidEntityType, obj)
 	}
@@ -220,6 +235,8 @@ func Decode[T EntityTypes](entity Entity) (T, error) {
 		return decodeJobCursor[T](entity)
 	case JobEvent:
 		return decodeJobEvent[T](entity)
+	case JobGroup:
+		return decodeJobGroup[T](entity)
 	default:
 		return out, fmt.Errorf("%w `%T` not supported", ErrInvalidEntityType, typ)
 	}
@@ -241,6 +258,30 @@ func decodeJobEvent[T EntityTypes](entity Entity) (T, error) {
 		return empty, err
 	}
 	j.IsNotified = isNotified
+	return out, nil
+}
+
+func decodeJobGroup[T EntityTypes](e Entity) (T, error) {
+	var out, empty T
+	group, ok := any(&out).(*JobGroup)
+	if !ok {
+		return empty, fmt.Errorf("%w `%T` not supported", ErrInvalidEntityType, group)
+	}
+	group.ID, group.CreatedAt, group.UpdatedAt = e.ID, e.CreatedAt, e.UpdatedAt
+	vals := e.Values
+	var err error
+	if group.Type, err = resolve[string](vals, "type"); err != nil {
+		return empty, err
+	}
+	if group.Status, err = resolveType[GroupStatus](vals, "status"); err != nil {
+		return empty, err
+	}
+	if group.ErrorMessage, err = resolve[string](vals, "error_message"); err != nil {
+		return empty, err
+	}
+	if group.Labels, err = resolveLabels(vals, "labels"); err != nil {
+		return empty, err
+	}
 	return out, nil
 }
 

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -111,6 +111,28 @@ func TestTransformToEntities(t *testing.T) {
 			},
 		},
 		{
+			name:       "success case JobGroups",
+			entityName: query.EntityNameJobGroups,
+			input: []map[string]any{
+				{
+					"id":         uID.String(),
+					"created_at": now, "updated_at": now,
+					"type":          "batch-sync",
+					"status":        "CREATED",
+					"error_message": "",
+					"labels":        nil,
+				},
+			},
+			expected: []orbital.Entity{
+				{
+					Name:      query.EntityNameJobGroups,
+					ID:        uID,
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+			},
+		},
+		{
 			name:       "error case JobCursor for a mandatory field filed missing",
 			entityName: query.EntityNameJobCursor,
 			input: []map[string]any{
@@ -380,6 +402,80 @@ func TestEncodes(t *testing.T) {
 					"created_at":  unixTime,
 					"updated_at":  unixTime,
 					"is_notified": true,
+				},
+			},
+		}
+
+		// when
+		result, err := orbital.Encodes(input...)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, expected, result)
+	})
+	t.Run("success JobGroup", func(t *testing.T) {
+		input := []orbital.JobGroup{
+			{
+				ID:           uID,
+				Type:         "batch-sync",
+				Status:       orbital.GroupStatusCreated,
+				ErrorMessage: "",
+				Labels:       orbital.Labels{"env": "prod"},
+				CreatedAt:    unixTime,
+				UpdatedAt:    unixTime,
+			},
+		}
+		expected := []orbital.Entity{
+			{
+				Name:      query.EntityNameJobGroups,
+				ID:        uID,
+				CreatedAt: unixTime,
+				UpdatedAt: unixTime,
+				Values: map[string]any{
+					"id":            uID,
+					"type":          "batch-sync",
+					"status":        orbital.GroupStatusCreated,
+					"error_message": "",
+					"created_at":    unixTime,
+					"updated_at":    unixTime,
+					"labels":        []byte(`{"env":"prod"}`),
+				},
+			},
+		}
+
+		// when
+		result, err := orbital.Encodes(input...)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, expected, result)
+	})
+	t.Run("success JobGroup with nil labels", func(t *testing.T) {
+		input := []orbital.JobGroup{
+			{
+				ID:           uID,
+				Type:         "batch-sync",
+				Status:       orbital.GroupStatusCreated,
+				ErrorMessage: "",
+				Labels:       nil,
+				CreatedAt:    unixTime,
+				UpdatedAt:    unixTime,
+			},
+		}
+		expected := []orbital.Entity{
+			{
+				Name:      query.EntityNameJobGroups,
+				ID:        uID,
+				CreatedAt: unixTime,
+				UpdatedAt: unixTime,
+				Values: map[string]any{
+					"id":            uID,
+					"type":          "batch-sync",
+					"status":        orbital.GroupStatusCreated,
+					"error_message": "",
+					"created_at":    unixTime,
+					"updated_at":    unixTime,
+					"labels":        []byte("null"),
 				},
 			},
 		}
@@ -721,6 +817,96 @@ func TestDecodes(t *testing.T) {
 					delete(entity.Values, key)
 
 					_, err := orbital.Decodes[orbital.JobEvent](entity)
+					assert.Error(t, err)
+				})
+			}
+		})
+	})
+	t.Run("decodes JobGroup", func(t *testing.T) {
+		t.Run("success", func(t *testing.T) {
+			// given
+			group1 := orbital.JobGroup{
+				ID:           uuid.New(),
+				Type:         "batch-sync",
+				Status:       orbital.GroupStatusCreated,
+				ErrorMessage: "",
+				Labels:       orbital.Labels{"env": "prod"},
+				UpdatedAt:    clock.NowUnixNano(),
+				CreatedAt:    clock.NowUnixNano(),
+			}
+			group2 := orbital.JobGroup{
+				ID:           uuid.New(),
+				Type:         "full-sync",
+				Status:       orbital.GroupStatusFailed,
+				ErrorMessage: "something went wrong",
+				Labels:       orbital.Labels{"env": "dev"},
+				UpdatedAt:    clock.NowUnixNano(),
+				CreatedAt:    clock.NowUnixNano(),
+			}
+
+			in, _ := orbital.Encodes(group1, group2)
+
+			// when
+			result, err := orbital.Decodes[orbital.JobGroup](in...)
+
+			// then
+			assert.NoError(t, err)
+			assert.Len(t, result, 2)
+			assert.Equal(t, group1, result[0])
+			assert.Equal(t, group2, result[1])
+		})
+		t.Run("success with nil Labels", func(t *testing.T) {
+			// given
+			group := orbital.JobGroup{
+				ID:           uuid.New(),
+				Type:         "batch-sync",
+				Status:       orbital.GroupStatusCreated,
+				ErrorMessage: "",
+				Labels:       nil,
+				UpdatedAt:    clock.NowUnixNano(),
+				CreatedAt:    clock.NowUnixNano(),
+			}
+
+			in, _ := orbital.Encodes(group)
+
+			// when
+			result, err := orbital.Decodes[orbital.JobGroup](in...)
+
+			// then
+			assert.NoError(t, err)
+			assert.Len(t, result, 1)
+			assert.Nil(t, result[0].Labels)
+			assert.Equal(t, group, result[0])
+		})
+		t.Run("error for missing fields in values for the key", func(t *testing.T) {
+			keysToDelete := []string{
+				"type",
+				"status",
+				"error_message",
+				"labels",
+			}
+
+			for _, key := range keysToDelete {
+				t.Run(key, func(t *testing.T) {
+					id := uuid.New()
+					entity := orbital.Entity{
+						Name:      query.EntityNameJobGroups,
+						ID:        id,
+						CreatedAt: 0,
+						UpdatedAt: 0,
+						Values: map[string]any{
+							"id":            id,
+							"type":          "batch-sync",
+							"status":        "CREATED",
+							"error_message": "",
+							"labels":        orbital.Labels(nil),
+							"updated_at":    0,
+							"created_at":    0,
+						},
+					}
+					delete(entity.Values, key)
+
+					_, err := orbital.Decodes[orbital.JobGroup](entity)
 					assert.Error(t, err)
 				})
 			}

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -297,7 +297,7 @@ func TestEncodes(t *testing.T) {
 					"status":        orbital.JobStatusCreated,
 					"type":          "baz-type",
 					"external_id":   "ext-id",
-					"labels":        []byte(nil),
+					"labels":        []byte("null"),
 				},
 			},
 		}

--- a/repository.go
+++ b/repository.go
@@ -111,10 +111,12 @@ func (r *Repository) updateJob(ctx context.Context, job Job) error {
 func (r *Repository) listJobs(ctx context.Context, jobsQuery ListJobsQuery) ([]Job, error) {
 	q := query.Query{
 		EntityName: query.EntityNameJobs,
-		Clauses: []query.Clause{
-			query.ClauseWithCreatedBefore(jobsQuery.CreatedAt),
-		},
-		Limit: jobsQuery.Limit,
+		Clauses:    []query.Clause{},
+		Limit:      jobsQuery.Limit,
+	}
+
+	if jobsQuery.CreatedAt > 0 {
+		q.Clauses = append(q.Clauses, query.ClauseWithCreatedBefore(jobsQuery.CreatedAt))
 	}
 
 	if string(jobsQuery.Status) != "" {

--- a/repository.go
+++ b/repository.go
@@ -437,3 +437,33 @@ func (r *Repository) getJobForUpdate(ctx context.Context, id uuid.UUID) (Job, bo
 
 	return *job, true, nil
 }
+
+// createJobGroup creates a new job group entity in the repository.
+// It takes a context and a JobGroup object as input and returns the created JobGroup object or an error if the operation fails.
+func (r *Repository) createJobGroup(ctx context.Context, group JobGroup) (JobGroup, error) {
+	return createEntity(ctx, group, r)
+}
+
+// getJobGroup retrieves a job group entity from the repository by its ID.
+// It takes a context and a UUID as input and returns the JobGroup entity,
+// a boolean indicating if the job group was found, and an error if the operation fails.
+func (r *Repository) getJobGroup(ctx context.Context, id uuid.UUID) (JobGroup, bool, error) {
+	group, err := getEntity[JobGroup](ctx, r,
+		query.Query{
+			EntityName: query.EntityNameJobGroups,
+			Clauses:    []query.Clause{query.ClauseWithID(id)},
+		})
+	if err != nil || group == nil {
+		return JobGroup{}, false, err
+	}
+
+	return *group, true, nil
+}
+
+// listJobsByGroupID retrieves all jobs belonging to a specific job group.
+// It takes a context and a group UUID as input and returns a slice of Job entities or an error if the operation fails.
+func (r *Repository) listJobsByGroupID(ctx context.Context, groupID uuid.UUID) ([]Job, error) {
+	return r.listJobs(ctx, ListJobsQuery{
+		Labels: Labels{LabelKeyGroupID: groupID.String()},
+	})
+}

--- a/store.go
+++ b/store.go
@@ -33,9 +33,9 @@ type (
 type TransactionFunc func(context.Context, Repository) error
 
 // EntityTypes defines a type constraint for entities that can be used in the repository.
-// It allows only types Job, Task, or JobCursor to satisfy this interface.
+// It allows only types Job, Task, JobCursor, JobEvent, or JobGroup to satisfy this interface.
 type EntityTypes interface {
-	Job | Task | JobCursor | JobEvent
+	Job | Task | JobCursor | JobEvent | JobGroup
 }
 
 type FindResult struct {

--- a/store/query/query.go
+++ b/store/query/query.go
@@ -26,8 +26,8 @@ const (
 	EntityNameJobGroups                       EntityName = "job_groups"
 )
 
-// SupportedEntityNames contains all valid entity names.
-var SupportedEntityNames = map[EntityName]struct{}{
+// ValidEntityNames contains all valid entity names.
+var ValidEntityNames = map[EntityName]struct{}{
 	EntityNameJobs:      {},
 	EntityNameTasks:     {},
 	EntityNameJobCursor: {},

--- a/store/query/query.go
+++ b/store/query/query.go
@@ -23,7 +23,17 @@ const (
 	EntityNameTasks                           EntityName = "tasks"
 	EntityNameJobCursor                       EntityName = "job_cursor"
 	EntityNameJobEvent                        EntityName = "job_event"
+	EntityNameJobGroups                       EntityName = "job_groups"
 )
+
+// SupportedEntityNames contains all valid entity names.
+var SupportedEntityNames = map[EntityName]struct{}{
+	EntityNameJobs:      {},
+	EntityNameTasks:     {},
+	EntityNameJobCursor: {},
+	EntityNameJobEvent:  {},
+	EntityNameJobGroups: {},
+}
 
 type RetrievalMode int
 

--- a/store/sql/sql.go
+++ b/store/sql/sql.go
@@ -29,6 +29,8 @@ var (
 )
 
 // New initializes a new SQL store and sets up required tables.
+//
+//nolint:funlen
 func New(ctx context.Context, db *sql.DB) (*SQL, error) {
 	s := &SQL{
 		db: db,
@@ -80,7 +82,16 @@ func New(ctx context.Context, db *sql.DB) (*SQL, error) {
 			is_notified BOOLEAN NOT NULL,
 			updated_at BIGINT NOT NULL,
 			created_at BIGINT NOT NULL
-        );`
+        );
+		CREATE TABLE IF NOT EXISTS job_groups(
+			id UUID PRIMARY KEY,
+			type VARCHAR(100) NOT NULL,
+			status VARCHAR(100) NOT NULL,
+			error_message TEXT,
+			labels JSONB,
+			updated_at BIGINT NOT NULL,
+			created_at BIGINT NOT NULL
+		);`
 	return s, s.execContext(ctx, stmt)
 }
 


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       feat
- description:   prepare and get job groups

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
Implemented `PrepareJobGroup` and `GetJobGroup` funcs for creating and retrieving job groups with ordered jobs, using reserved `orbital/` label keys to store group membership and ordering on jobs.