### PR TITLE
fix(test): pin rabbitmq image version

### DIFF
--- a/client/amqp/amqp_test.go
+++ b/client/amqp/amqp_test.go
@@ -623,7 +623,10 @@ func TestReceiveTaskResponse(t *testing.T) {
 
 func startRabbitMQ(ctx context.Context, opts ...containerOpts) (testcontainers.Container, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        "rabbitmq:4",
+		// Pin to 4.2 to avoid breaking changes in 4.3+ where AMQP 1.0 v1 address format
+		// is denied by default and v2 format requires queues to be pre-created.
+		// See: https://www.rabbitmq.com/docs/amqp#address-v2
+		Image:        "rabbitmq:4.2",
 		ExposedPorts: []string{"5672/tcp", "5671/tcp", "15672/tcp"},
 		WaitingFor: wait.ForAll(
 			wait.ForListeningPort("5672/tcp"),

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -114,7 +114,10 @@ func setupTestEnvironment(ctx context.Context, t *testing.T) (*testEnvironment, 
 	g.Go(func() error {
 		t.Log("Starting RabbitMQ container...")
 
-		rabbitContainer, err := rabbitmq.Run(ctx, "rabbitmq:4-management",
+		// Pin to 4.2 to avoid breaking changes in 4.3+ where AMQP 1.0 v1 address format
+		// is denied by default and v2 format requires queues to be pre-created.
+		// See: https://www.rabbitmq.com/docs/amqp#address-v2
+		rabbitContainer, err := rabbitmq.Run(ctx, "rabbitmq:4.2-management",
 			rabbitmq.WithAdminUsername("guest"),
 			rabbitmq.WithAdminPassword("guest"),
 			testcontainers.WithWaitStrategy(

--- a/regression/helper_test.go
+++ b/regression/helper_test.go
@@ -96,7 +96,10 @@ func setupEnv(ctx context.Context, t *testing.T, dbName string) (*testEnvironmen
 	errGrp.Go(func() error {
 		t.Log("Starting RabbitMQ container...")
 
-		rabbitContainer, err := rabbitmq.Run(ctx, "rabbitmq:4-management",
+		// Pin to 4.2 to avoid breaking changes in 4.3+ where AMQP 1.0 v1 address format
+		// is denied by default and v2 format requires queues to be pre-created.
+		// See: https://www.rabbitmq.com/docs/amqp#address-v2
+		rabbitContainer, err := rabbitmq.Run(ctx, "rabbitmq:4.2-management",
 			testcontainers.WithWaitStrategy(
 				wait.ForAll(
 					wait.ForLog("Server startup complete").WithStartupTimeout(60*time.Second),


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       fix
- description:   pin rabbitmq image version

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
Pin RabbitMQ test images to minor version 4.2 to avoid AMQP 1.0 v1 address format being denied by default in 4.3+.
