### PR TITLE
feat(manager): add CancelJobGroup to cancel a job group

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,6 +7,7 @@ linters:
     - ginkgolinter
     - gochecknoglobals
     - gochecknoinits
+    - goconst
     - godox
     - lll
     - musttag
@@ -47,7 +48,6 @@ linters:
       - linters:
           - dupl
           - funlen
-          - goconst
           - maintidx
           - cyclop
           - nilerr
@@ -55,7 +55,7 @@ linters:
     paths:
       - third_party$
       - builtin$
-      - examples$
+      - examples/
 formatters:
   enable:
     - gci
@@ -76,4 +76,4 @@ formatters:
     paths:
       - third_party$
       - builtin$
-      - examples$
+      - examples/

--- a/client/embedded/embedded.go
+++ b/client/embedded/embedded.go
@@ -102,7 +102,7 @@ func (c *Client) SendTaskRequest(ctx context.Context, request orbital.TaskReques
 	}
 
 	// process the request asynchronously with its own context
-	//nolint:contextcheck
+	//nolint:contextcheck,gosec
 	go func() {
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), c.config.handlerTimeout)
 		defer cancel()

--- a/jobgroup.go
+++ b/jobgroup.go
@@ -50,6 +50,11 @@ func (jg JobGroup) WithLabels(labels Labels) JobGroup {
 	return jg
 }
 
+// isCancelable reports whether the group can be canceled based on its current status.
+func (jg JobGroup) isCancelable() bool {
+	return jg.Status == GroupStatusCreated || jg.Status == GroupStatusProcessing
+}
+
 // sortJobsByGroupOrder sorts jobs in-place by their group order key (ascending).
 // Returns an error if any job has an invalid or missing order key.
 func sortJobsByGroupOrder(jobs []Job) error {

--- a/manager.go
+++ b/manager.go
@@ -104,6 +104,8 @@ var (
 	ErrUpdatingJob             = errors.New("failed to update job")
 	ErrTaskNotFound            = errors.New("task not found")
 	ErrJobGroupEmpty           = errors.New("job group must not be empty")
+	ErrJobGroupNotFound        = errors.New("job group not found")
+	ErrJobGroupUnCancelable    = errors.New("job group cannot be canceled in its current state")
 )
 
 // NewManager creates a new Manager instance.
@@ -426,6 +428,28 @@ func (m *Manager) GetJobGroup(ctx context.Context, groupID uuid.UUID) (JobGroup,
 	group.Jobs = jobs
 
 	return group, true, nil
+}
+
+// CancelJobGroup cancels a job group. Scheduled jobs will no longer be promoted.
+// Returns ErrJobGroupNotFound or ErrJobGroupUnCancelable if already terminal.
+func (m *Manager) CancelJobGroup(ctx context.Context, groupID uuid.UUID) error {
+	return m.repo.transaction(ctx, func(ctx context.Context, repo Repository) error {
+		slogctx.Debug(ctx, "canceling job group", "groupId", groupID)
+		group, found, err := repo.getJobGroupForUpdate(ctx, groupID)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return ErrJobGroupNotFound
+		}
+		if !group.isCancelable() {
+			return ErrJobGroupUnCancelable
+		}
+
+		group.Status = GroupStatusCanceled
+		group.ErrorMessage = "group has been canceled by the user"
+		return repo.updateJobGroup(ctx, group)
+	})
 }
 
 // scheduleJobGroup manages sequential job execution within groups.

--- a/manager_test.go
+++ b/manager_test.go
@@ -1909,3 +1909,144 @@ func TestScheduleJobGroup(t *testing.T) {
 		assert.Equal(t, orbital.JobStatusScheduled, result.Jobs[1].Status)
 	})
 }
+
+func TestCancelJobGroup(t *testing.T) {
+	t.Run("should cancel group", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			promote bool
+		}{
+			{name: "CREATED", promote: false},
+			{name: "PROCESSING", promote: true},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				// given
+				db, store := createSQLStore(t)
+				defer clearTables(t, db)
+				repo := orbital.NewRepository(store)
+
+				subj, err := orbital.NewManager(repo, mockTaskResolveFunc())
+				assert.NoError(t, err)
+
+				ctx := t.Context()
+
+				group, err := subj.PrepareJobGroup(ctx, orbital.NewJobGroup("batch-sync",
+					orbital.Job{Type: "job-type", Data: []byte("job-1")},
+					orbital.Job{Type: "job-type", Data: []byte("job-2")},
+				))
+				assert.NoError(t, err)
+
+				if tt.promote {
+					err = orbital.ScheduleJobGroup(subj)(ctx)
+					assert.NoError(t, err)
+				}
+
+				// when
+				err = subj.CancelJobGroup(ctx, group.ID)
+
+				// then
+				assert.NoError(t, err)
+
+				result, ok, err := subj.GetJobGroup(ctx, group.ID)
+				assert.NoError(t, err)
+				assert.True(t, ok)
+				assert.Equal(t, orbital.GroupStatusCanceled, result.Status)
+				assert.Equal(t, "group has been canceled by the user", result.ErrorMessage)
+			})
+		}
+	})
+
+	t.Run("group not found", func(t *testing.T) {
+		// given
+		db, store := createSQLStore(t)
+		defer clearTables(t, db)
+		repo := orbital.NewRepository(store)
+
+		subj, err := orbital.NewManager(repo, mockTaskResolveFunc())
+		assert.NoError(t, err)
+
+		// when
+		err = subj.CancelJobGroup(t.Context(), uuid.New())
+
+		// then
+		assert.ErrorIs(t, err, orbital.ErrJobGroupNotFound)
+	})
+
+	t.Run("should not cancel terminal group", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			status orbital.GroupStatus
+		}{
+			{name: "DONE", status: orbital.GroupStatusDone},
+			{name: "FAILED", status: orbital.GroupStatusFailed},
+			{name: "CANCELED", status: orbital.GroupStatusCanceled},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				// given
+				db, store := createSQLStore(t)
+				defer clearTables(t, db)
+				repo := orbital.NewRepository(store)
+
+				subj, err := orbital.NewManager(repo, mockTaskResolveFunc())
+				assert.NoError(t, err)
+
+				ctx := t.Context()
+
+				group, err := subj.PrepareJobGroup(ctx, orbital.NewJobGroup("batch-sync",
+					orbital.Job{Type: "job-type", Data: []byte("job-1")},
+				))
+				assert.NoError(t, err)
+
+				err = orbital.UpdateJobGroup(repo)(ctx, orbital.JobGroup{
+					ID:     group.ID,
+					Type:   group.Type,
+					Status: tt.status,
+				})
+				assert.NoError(t, err)
+
+				// when
+				err = subj.CancelJobGroup(ctx, group.ID)
+
+				// then
+				assert.ErrorIs(t, err, orbital.ErrJobGroupUnCancelable)
+			})
+		}
+	})
+
+	t.Run("scheduler should not promote jobs after group is canceled", func(t *testing.T) {
+		// given
+		db, store := createSQLStore(t)
+		defer clearTables(t, db)
+		repo := orbital.NewRepository(store)
+
+		subj, err := orbital.NewManager(repo, mockTaskResolveFunc())
+		assert.NoError(t, err)
+
+		ctx := t.Context()
+
+		group, err := subj.PrepareJobGroup(ctx, orbital.NewJobGroup("batch-sync",
+			orbital.Job{Type: "job-type", Data: []byte("job-1")},
+			orbital.Job{Type: "job-type", Data: []byte("job-2")},
+		))
+		assert.NoError(t, err)
+
+		// cancel before any scheduling
+		err = subj.CancelJobGroup(ctx, group.ID)
+		assert.NoError(t, err)
+
+		// when - run scheduler
+		err = orbital.ScheduleJobGroup(subj)(ctx)
+		assert.NoError(t, err)
+
+		// then - jobs remain SCHEDULED, group remains CANCELED
+		result, _, err := subj.GetJobGroup(ctx, group.ID)
+		assert.NoError(t, err)
+		assert.Equal(t, orbital.GroupStatusCanceled, result.Status)
+		assert.Equal(t, orbital.JobStatusScheduled, result.Jobs[0].Status)
+		assert.Equal(t, orbital.JobStatusScheduled, result.Jobs[1].Status)
+	})
+}

--- a/repository.go
+++ b/repository.go
@@ -470,6 +470,22 @@ func (r *Repository) getJobGroup(ctx context.Context, id uuid.UUID) (JobGroup, b
 	return *group, true, nil
 }
 
+// getJobGroupForUpdate retrieves a job group entity by its ID and ensures that the group is locked for update.
+func (r *Repository) getJobGroupForUpdate(ctx context.Context, id uuid.UUID) (JobGroup, bool, error) {
+	q := query.Query{
+		EntityName:    query.EntityNameJobGroups,
+		Clauses:       []query.Clause{query.ClauseWithID(id)},
+		RetrievalMode: query.RetrievalModeForUpdate,
+	}
+
+	group, err := getEntity[JobGroup](ctx, r, q)
+	if err != nil || group == nil {
+		return JobGroup{}, false, err
+	}
+
+	return *group, true, nil
+}
+
 // listOrderedGroupJobs retrieves all jobs belonging to a specific job group, sorted by their group order.
 func (r *Repository) listOrderedGroupJobs(ctx context.Context, groupID uuid.UUID) ([]Job, error) {
 	jobs, err := r.listJobs(ctx, ListJobsQuery{

--- a/repository_test.go
+++ b/repository_test.go
@@ -533,7 +533,6 @@ func TestRepoCreateTasks(t *testing.T) {
 			assert.Equal(t, jobID, fetchedTask.JobID)
 			assert.Equal(t, taskType, fetchedTask.Type)
 			assert.Equal(t, fmt.Sprintf("working-state-%v", index), string(fetchedTask.WorkingState))
-			//nolint:gosec
 			assert.Equal(t, uint64(index), fetchedTask.ReconcileCount)
 			assert.Equal(t, fmt.Sprintf("etag-%v", index), fetchedTask.ETag)
 			assert.Equal(t, fmt.Sprintf("error-message-%v", index), fetchedTask.ErrorMessage)


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       feat
- description:   add CancelJobGroup to cancel a job group

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
Implements `CancelJobGroup` on manager that transitions a group to CANCELED status, preventing scheduled jobs from being promoted, with a `getJobGroupForUpdate` repository method for row-level locking and an `isCancelable()` helper on JobGroup.