### PR TITLE
feat: implement group terminated events for JobGroup lifecycle

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,6 +4,7 @@ linters:
   disable:
     - depguard
     - exhaustruct
+    - funlen
     - ginkgolinter
     - gochecknoglobals
     - gochecknoinits

--- a/export_test.go
+++ b/export_test.go
@@ -121,10 +121,34 @@ func ScheduleJobGroup(m *Manager) func(ctx context.Context) error {
 	return m.scheduleJobGroup
 }
 
+func CreateJobGroup(r *Repository) func(ctx context.Context, group JobGroup) (JobGroup, error) {
+	return r.createJobGroup
+}
+
 func ListJobGroups(r *Repository) func(ctx context.Context, q ListJobGroupsQuery) ([]JobGroup, error) {
 	return r.listJobGroups
 }
 
 func UpdateJobGroup(r *Repository) func(ctx context.Context, group JobGroup) error {
 	return r.updateJobGroup
+}
+
+func CreateJobGroupEvent(r *Repository) func(ctx context.Context, event JobGroupEvent) (JobGroupEvent, error) {
+	return r.createJobGroupEvent
+}
+
+func GetJobGroupEvent(r *Repository) func(ctx context.Context, q ListJobGroupEventQuery) (JobGroupEvent, bool, error) {
+	return r.getJobGroupEvent
+}
+
+func UpdateJobGroupEvent(r *Repository) func(ctx context.Context, event JobGroupEvent) error {
+	return r.updateJobGroupEvent
+}
+
+func RecordGroupTerminatedEvent(m *Manager) func(ctx context.Context, repo Repository, group JobGroup) error {
+	return m.recordGroupTerminatedEvent
+}
+
+func SendGroupTerminatedEvent(m *Manager) func(ctx context.Context) error {
+	return m.sendGroupTerminatedEvent
 }

--- a/export_test.go
+++ b/export_test.go
@@ -145,10 +145,10 @@ func UpdateJobGroupEvent(r *Repository) func(ctx context.Context, event JobGroup
 	return r.updateJobGroupEvent
 }
 
-func RecordGroupTerminatedEvent(m *Manager) func(ctx context.Context, repo Repository, group JobGroup) error {
-	return m.recordGroupTerminatedEvent
+func RecordJobGroupTerminatedEvent(m *Manager) func(ctx context.Context, repo Repository, group JobGroup) error {
+	return m.recordJobGroupTerminatedEvent
 }
 
-func SendGroupTerminatedEvent(m *Manager) func(ctx context.Context) error {
-	return m.sendGroupTerminatedEvent
+func SendJobGroupTerminatedEvent(m *Manager) func(ctx context.Context) error {
+	return m.sendJobGroupTerminatedEvent
 }

--- a/helper_test.go
+++ b/helper_test.go
@@ -131,7 +131,7 @@ func mockTerminatedFunc() orbital.JobTerminatedEventFunc {
 	}
 }
 
-func mockGroupTerminatedFunc() orbital.GroupTerminatedEventFunc {
+func mockJobGroupTerminatedFunc() orbital.JobGroupTerminatedEventFunc {
 	return func(_ context.Context, _ orbital.JobGroup) error {
 		return nil
 	}

--- a/helper_test.go
+++ b/helper_test.go
@@ -68,6 +68,7 @@ func clearTables(t *testing.T, db *stdsql.DB) {
 	assert.NoError(t, clearJobCursorTable(ctx, db))
 	assert.NoError(t, clearJobEventTable(ctx, db))
 	assert.NoError(t, clearJobGroupsTable(ctx, db))
+	assert.NoError(t, clearJobGroupEventsTable(ctx, db))
 }
 
 func clearJobTable(ctx context.Context, db *stdsql.DB) error {
@@ -92,6 +93,11 @@ func clearJobEventTable(ctx context.Context, db *stdsql.DB) error {
 
 func clearJobGroupsTable(ctx context.Context, db *stdsql.DB) error {
 	_, err := db.ExecContext(ctx, "DELETE FROM job_groups")
+	return err
+}
+
+func clearJobGroupEventsTable(ctx context.Context, db *stdsql.DB) error {
+	_, err := db.ExecContext(ctx, "DELETE FROM job_group_events")
 	return err
 }
 
@@ -121,6 +127,12 @@ func mockTaskResolveFunc() orbital.TaskResolveFunc {
 
 func mockTerminatedFunc() orbital.JobTerminatedEventFunc {
 	return func(_ context.Context, _ orbital.Job) error {
+		return nil
+	}
+}
+
+func mockGroupTerminatedFunc() orbital.GroupTerminatedEventFunc {
+	return func(_ context.Context, _ orbital.JobGroup) error {
 		return nil
 	}
 }

--- a/job.go
+++ b/job.go
@@ -22,10 +22,10 @@ const (
 
 // Reserved label keys for job group functionality.
 const (
-	// LabelKeyGroupID is the label key for storing the parent group's UUID.
-	LabelKeyGroupID = "orbital/group-id"
-	// LabelKeyGroupOrderKey is the label key for storing the job's position within the group.
-	LabelKeyGroupOrderKey = "orbital/group-order-key"
+	// LabelKeyJobGroupID is the label key for storing the parent job group's UUID.
+	LabelKeyJobGroupID = "orbital/job-group-id"
+	// LabelKeyJobGroupOrderKey is the label key for storing the job's position within the job group.
+	LabelKeyJobGroupOrderKey = "orbital/job-group-order-key"
 )
 
 type (

--- a/jobgroup.go
+++ b/jobgroup.go
@@ -55,6 +55,11 @@ func (jg JobGroup) isCancelable() bool {
 	return jg.Status == GroupStatusCreated || jg.Status == GroupStatusProcessing
 }
 
+// isTerminal reports whether the group has reached a terminal state.
+func (jg JobGroup) isTerminal() bool {
+	return jg.Status == GroupStatusDone || jg.Status == GroupStatusFailed || jg.Status == GroupStatusCanceled
+}
+
 // sortJobsByGroupOrder sorts jobs in-place by their group order key (ascending).
 // Returns an error if any job has an invalid or missing order key.
 func sortJobsByGroupOrder(jobs []Job) error {

--- a/jobgroup.go
+++ b/jobgroup.go
@@ -9,13 +9,13 @@ import (
 	"github.com/google/uuid"
 )
 
-// Possible group statuses.
+// Possible job group statuses.
 const (
-	GroupStatusCreated    GroupStatus = "CREATED"
-	GroupStatusProcessing GroupStatus = "PROCESSING"
-	GroupStatusDone       GroupStatus = "DONE"
-	GroupStatusFailed     GroupStatus = "FAILED"
-	GroupStatusCanceled   GroupStatus = "CANCELED"
+	JobGroupStatusCreated    JobGroupStatus = "CREATED"
+	JobGroupStatusProcessing JobGroupStatus = "PROCESSING"
+	JobGroupStatusDone       JobGroupStatus = "DONE"
+	JobGroupStatusFailed     JobGroupStatus = "FAILED"
+	JobGroupStatusCanceled   JobGroupStatus = "CANCELED"
 )
 
 type (
@@ -26,13 +26,13 @@ type (
 		Jobs         []Job // Jobs in the group, ordered by their position
 		CreatedAt    int64
 		UpdatedAt    int64
-		Status       GroupStatus
+		Status       JobGroupStatus
 		Labels       Labels
 		ErrorMessage string
 	}
 
-	// GroupStatus represents the possible statuses of a JobGroup.
-	GroupStatus string
+	// JobGroupStatus represents the possible statuses of a JobGroup.
+	JobGroupStatus string
 )
 
 // NewJobGroup creates a new JobGroup with the provided type and jobs.
@@ -50,92 +50,92 @@ func (jg JobGroup) WithLabels(labels Labels) JobGroup {
 	return jg
 }
 
-// isCancelable reports whether the group can be canceled based on its current status.
+// isCancelable reports whether the job group can be canceled based on its current status.
 func (jg JobGroup) isCancelable() bool {
-	return jg.Status == GroupStatusCreated || jg.Status == GroupStatusProcessing
+	return jg.Status == JobGroupStatusCreated || jg.Status == JobGroupStatusProcessing
 }
 
-// isTerminal reports whether the group has reached a terminal state.
-func (jg JobGroup) isTerminal() bool {
-	return jg.Status == GroupStatusDone || jg.Status == GroupStatusFailed || jg.Status == GroupStatusCanceled
+// hasTerminalState reports whether the job group has reached a terminal state.
+func (jg JobGroup) hasTerminalState() bool {
+	return jg.Status == JobGroupStatusDone || jg.Status == JobGroupStatusFailed || jg.Status == JobGroupStatusCanceled
 }
 
-// sortJobsByGroupOrder sorts jobs in-place by their group order key (ascending).
+// sortJobsByGroupOrder sorts jobs in-place by their job group order key (ascending).
 // Returns an error if any job has an invalid or missing order key.
 func sortJobsByGroupOrder(jobs []Job) error {
 	for _, job := range jobs {
-		if _, err := strconv.Atoi(job.Labels[LabelKeyGroupOrderKey]); err != nil {
-			return fmt.Errorf("job %s has invalid or missing group order key: %w", job.ID, err)
+		if _, err := strconv.Atoi(job.Labels[LabelKeyJobGroupOrderKey]); err != nil {
+			return fmt.Errorf("job %s has invalid or missing job group order key: %w", job.ID, err)
 		}
 	}
 
 	sort.Slice(jobs, func(i, j int) bool {
-		orderI, _ := strconv.Atoi(jobs[i].Labels[LabelKeyGroupOrderKey])
-		orderJ, _ := strconv.Atoi(jobs[j].Labels[LabelKeyGroupOrderKey])
+		orderI, _ := strconv.Atoi(jobs[i].Labels[LabelKeyJobGroupOrderKey])
+		orderJ, _ := strconv.Atoi(jobs[j].Labels[LabelKeyJobGroupOrderKey])
 		return orderI < orderJ
 	})
 
 	return nil
 }
 
-// groupResult represents the outcome of evaluating the jobs in a group.
-// Each implementation knows how to apply itself to transition the group state.
-type groupResult interface {
+// jobGroupResult represents the outcome of evaluating the jobs in a job group.
+// Each implementation knows how to apply itself to transition the job group state.
+type jobGroupResult interface {
 	apply(ctx context.Context, repo Repository, group *JobGroup) error
 }
 
-type groupWaitResult struct{}
+type jobGroupWaitResult struct{}
 
-func (groupWaitResult) apply(ctx context.Context, repo Repository, group *JobGroup) error {
+func (jobGroupWaitResult) apply(ctx context.Context, repo Repository, group *JobGroup) error {
 	return repo.updateJobGroup(ctx, *group)
 }
 
-type groupCompletedResult struct{}
+type jobGroupCompletedResult struct{}
 
-func (groupCompletedResult) apply(ctx context.Context, repo Repository, group *JobGroup) error {
-	group.Status = GroupStatusDone
+func (jobGroupCompletedResult) apply(ctx context.Context, repo Repository, group *JobGroup) error {
+	group.Status = JobGroupStatusDone
 	return repo.updateJobGroup(ctx, *group)
 }
 
-type groupFailedResult struct {
+type jobGroupFailedResult struct {
 	reason string
 }
 
-func (r groupFailedResult) apply(ctx context.Context, repo Repository, group *JobGroup) error {
-	group.Status = GroupStatusFailed
+func (r jobGroupFailedResult) apply(ctx context.Context, repo Repository, group *JobGroup) error {
+	group.Status = JobGroupStatusFailed
 	group.ErrorMessage = r.reason
 	return repo.updateJobGroup(ctx, *group)
 }
 
-type groupPromoteResult struct {
+type jobGroupPromoteResult struct {
 	job *Job
 }
 
-func (r groupPromoteResult) apply(ctx context.Context, repo Repository, group *JobGroup) error {
+func (r jobGroupPromoteResult) apply(ctx context.Context, repo Repository, group *JobGroup) error {
 	r.job.Status = JobStatusCreated
 	if err := repo.updateJob(ctx, *r.job); err != nil {
 		return err
 	}
-	group.Status = GroupStatusProcessing
+	group.Status = JobGroupStatusProcessing
 	return repo.updateJobGroup(ctx, *group)
 }
 
-// evaluateJobs inspects the jobs in order and returns a groupResult
-// representing the next action for the group's scheduling lifecycle.
-func evaluateJobs(jobs []Job) groupResult {
+// evaluateJobs inspects the jobs in order and returns a jobGroupResult
+// representing the next action for the job group's scheduling lifecycle.
+func evaluateJobs(jobs []Job) jobGroupResult {
 	for i := range jobs {
 		switch {
 		case jobs[i].Status == JobStatusDone:
 			continue
 		case isUnsuccessful(jobs[i].Status):
-			return groupFailedResult{reason: fmt.Sprintf("job %s failed or is canceled", jobs[i].ID)}
+			return jobGroupFailedResult{reason: fmt.Sprintf("job %s failed or is canceled", jobs[i].ID)}
 		case jobs[i].Status == JobStatusScheduled:
-			return groupPromoteResult{job: &jobs[i]}
+			return jobGroupPromoteResult{job: &jobs[i]}
 		default:
-			return groupWaitResult{}
+			return jobGroupWaitResult{}
 		}
 	}
-	return groupCompletedResult{}
+	return jobGroupCompletedResult{}
 }
 
 func isUnsuccessful(status JobStatus) bool {

--- a/jobgroup_test.go
+++ b/jobgroup_test.go
@@ -29,10 +29,10 @@ func TestNewJobGroup(t *testing.T) {
 
 	t.Run("should create job group with empty jobs list", func(t *testing.T) {
 		// when
-		group := orbital.NewJobGroup("empty-group")
+		group := orbital.NewJobGroup("empty-job-group")
 
 		// then
-		assert.Equal(t, "empty-group", group.Type)
+		assert.Equal(t, "empty-job-group", group.Type)
 		assert.Empty(t, group.Jobs)
 	})
 
@@ -44,7 +44,7 @@ func TestNewJobGroup(t *testing.T) {
 		}
 
 		// when
-		group := orbital.NewJobGroup("ordered-group", jobs...)
+		group := orbital.NewJobGroup("ordered-job-group", jobs...)
 
 		// then
 		assert.Len(t, group.Jobs, 5)
@@ -55,11 +55,11 @@ func TestNewJobGroup(t *testing.T) {
 
 	t.Run("should have zero-value fields for unset properties", func(t *testing.T) {
 		// when
-		group := orbital.NewJobGroup("test-group")
+		group := orbital.NewJobGroup("test-job-group")
 
 		// then
 		assert.Equal(t, uuid.Nil, group.ID)
-		assert.Equal(t, orbital.GroupStatus(""), group.Status)
+		assert.Equal(t, orbital.JobGroupStatus(""), group.Status)
 		assert.Nil(t, group.Labels)
 		assert.Empty(t, group.ErrorMessage)
 		assert.Zero(t, group.CreatedAt)
@@ -70,7 +70,7 @@ func TestNewJobGroup(t *testing.T) {
 func TestJobGroup_WithLabels(t *testing.T) {
 	t.Run("should set labels on job group", func(t *testing.T) {
 		// given
-		group := orbital.NewJobGroup("test-group")
+		group := orbital.NewJobGroup("test-job-group")
 		labels := orbital.Labels{"tenant": "acme", "priority": "high"}
 
 		// when
@@ -100,19 +100,19 @@ func TestJobGroup_WithLabels(t *testing.T) {
 
 	t.Run("should return modified job group for chaining", func(t *testing.T) {
 		// given
-		group := orbital.NewJobGroup("test-group")
+		group := orbital.NewJobGroup("test-job-group")
 
 		// when
 		result := group.WithLabels(orbital.Labels{"key": "value"})
 
 		// then
-		assert.Equal(t, "test-group", result.Type)
+		assert.Equal(t, "test-job-group", result.Type)
 		assert.Equal(t, "value", result.Labels["key"])
 	})
 
 	t.Run("should handle empty labels", func(t *testing.T) {
 		// given
-		group := orbital.NewJobGroup("test-group")
+		group := orbital.NewJobGroup("test-job-group")
 
 		// when
 		result := group.WithLabels(orbital.Labels{})
@@ -124,7 +124,7 @@ func TestJobGroup_WithLabels(t *testing.T) {
 
 	t.Run("should handle nil labels", func(t *testing.T) {
 		// given
-		group := orbital.NewJobGroup("test-group")
+		group := orbital.NewJobGroup("test-job-group")
 
 		// when
 		result := group.WithLabels(nil)
@@ -134,28 +134,28 @@ func TestJobGroup_WithLabels(t *testing.T) {
 	})
 }
 
-func TestGroupStatus(t *testing.T) {
+func TestJobGroupStatus(t *testing.T) {
 	t.Run("should have correct string values", func(t *testing.T) {
 		// then
-		assert.Equal(t, orbital.GroupStatusCreated, orbital.GroupStatus("CREATED"))
-		assert.Equal(t, orbital.GroupStatusProcessing, orbital.GroupStatus("PROCESSING"))
-		assert.Equal(t, orbital.GroupStatusDone, orbital.GroupStatus("DONE"))
-		assert.Equal(t, orbital.GroupStatusFailed, orbital.GroupStatus("FAILED"))
-		assert.Equal(t, orbital.GroupStatusCanceled, orbital.GroupStatus("CANCELED"))
+		assert.Equal(t, orbital.JobGroupStatusCreated, orbital.JobGroupStatus("CREATED"))
+		assert.Equal(t, orbital.JobGroupStatusProcessing, orbital.JobGroupStatus("PROCESSING"))
+		assert.Equal(t, orbital.JobGroupStatusDone, orbital.JobGroupStatus("DONE"))
+		assert.Equal(t, orbital.JobGroupStatusFailed, orbital.JobGroupStatus("FAILED"))
+		assert.Equal(t, orbital.JobGroupStatusCanceled, orbital.JobGroupStatus("CANCELED"))
 	})
 
 	t.Run("should have distinct values", func(t *testing.T) {
 		// given
-		statuses := []orbital.GroupStatus{
-			orbital.GroupStatusCreated,
-			orbital.GroupStatusProcessing,
-			orbital.GroupStatusDone,
-			orbital.GroupStatusFailed,
-			orbital.GroupStatusCanceled,
+		statuses := []orbital.JobGroupStatus{
+			orbital.JobGroupStatusCreated,
+			orbital.JobGroupStatusProcessing,
+			orbital.JobGroupStatusDone,
+			orbital.JobGroupStatusFailed,
+			orbital.JobGroupStatusCanceled,
 		}
 
 		// then
-		seen := make(map[orbital.GroupStatus]bool)
+		seen := make(map[orbital.JobGroupStatus]bool)
 		for _, status := range statuses {
 			assert.False(t, seen[status], "duplicate status: %s", status)
 			seen[status] = true
@@ -174,9 +174,9 @@ func TestSortJobsByGroupOrder(t *testing.T) {
 		{
 			name: "should sort jobs by order key ascending",
 			jobs: []orbital.Job{
-				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "2"}},
-				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "0"}},
-				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "1"}},
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyJobGroupOrderKey: "2"}},
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyJobGroupOrderKey: "0"}},
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyJobGroupOrderKey: "1"}},
 			},
 			expOrder: []string{"0", "1", "2"},
 		},
@@ -188,40 +188,40 @@ func TestSortJobsByGroupOrder(t *testing.T) {
 		{
 			name: "should handle single job",
 			jobs: []orbital.Job{
-				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "5"}},
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyJobGroupOrderKey: "5"}},
 			},
 			expOrder: []string{"5"},
 		},
 		{
 			name: "should return error when order key is missing",
 			jobs: []orbital.Job{
-				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "0"}},
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyJobGroupOrderKey: "0"}},
 				{ID: uuid.New(), Labels: orbital.Labels{"other": "label"}},
 			},
-			expErr: "invalid or missing group order key",
+			expErr: "invalid or missing job group order key",
 		},
 		{
 			name: "should return error when order key is not a number",
 			jobs: []orbital.Job{
-				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "0"}},
-				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "abc"}},
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyJobGroupOrderKey: "0"}},
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyJobGroupOrderKey: "abc"}},
 			},
-			expErr: "invalid or missing group order key",
+			expErr: "invalid or missing job group order key",
 		},
 		{
 			name: "should return error when labels are nil",
 			jobs: []orbital.Job{
-				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "0"}},
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyJobGroupOrderKey: "0"}},
 				{ID: uuid.New(), Labels: nil},
 			},
-			expErr: "invalid or missing group order key",
+			expErr: "invalid or missing job group order key",
 		},
 		{
 			name: "should sort jobs with large order keys",
 			jobs: []orbital.Job{
-				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "100"}},
-				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "10"}},
-				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyGroupOrderKey: "1"}},
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyJobGroupOrderKey: "100"}},
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyJobGroupOrderKey: "10"}},
+				{ID: uuid.New(), Labels: orbital.Labels{orbital.LabelKeyJobGroupOrderKey: "1"}},
 			},
 			expOrder: []string{"1", "10", "100"},
 		},
@@ -242,7 +242,7 @@ func TestSortJobsByGroupOrder(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Len(t, tt.jobs, len(tt.expOrder))
 			for i, expKey := range tt.expOrder {
-				assert.Equal(t, expKey, tt.jobs[i].Labels[orbital.LabelKeyGroupOrderKey])
+				assert.Equal(t, expKey, tt.jobs[i].Labels[orbital.LabelKeyJobGroupOrderKey])
 			}
 		})
 	}

--- a/jobgroupevent.go
+++ b/jobgroupevent.go
@@ -18,16 +18,16 @@ type JobGroupEvent struct {
 	CreatedAt  int64
 }
 
-// GroupTerminatedEventFunc is a callback invoked when a job group reaches a terminal state.
-type GroupTerminatedEventFunc func(ctx context.Context, group JobGroup) error
+// JobGroupTerminatedEventFunc is a callback invoked when a job group reaches a terminal state.
+type JobGroupTerminatedEventFunc func(ctx context.Context, group JobGroup) error
 
-// recordGroupTerminatedEvent creates or resets a group event record so that
-// sendGroupTerminatedEvent will pick it up for notification.
-// Returns nil immediately if no callback is registered for the group's status.
-func (m *Manager) recordGroupTerminatedEvent(ctx context.Context, repo Repository, group JobGroup) error {
-	eventFunc := m.groupEventFunc(group)
+// recordJobGroupTerminatedEvent creates or resets a job group event record so that
+// sendJobGroupTerminatedEvent will pick it up for notification.
+// Returns nil immediately if no callback is registered for the job group's status.
+func (m *Manager) recordJobGroupTerminatedEvent(ctx context.Context, repo Repository, group JobGroup) error {
+	eventFunc := m.jobGroupEventFunc(group)
 	if eventFunc == nil {
-		slogctx.Debug(ctx, "no group event function set, skipping event recording")
+		slogctx.Debug(ctx, "no job group event function set, skipping event recording")
 		return nil
 	}
 	event, ok, err := repo.getJobGroupEvent(ctx, ListJobGroupEventQuery{ID: group.ID})
@@ -45,9 +45,9 @@ func (m *Manager) recordGroupTerminatedEvent(ctx context.Context, repo Repositor
 	return nil
 }
 
-// sendGroupTerminatedEvent is a background worker that picks up unnotified group events,
+// sendJobGroupTerminatedEvent is a background worker that picks up unnotified job group events,
 // invokes the registered callback, and marks them as notified on success.
-func (m *Manager) sendGroupTerminatedEvent(ctx context.Context) error {
+func (m *Manager) sendJobGroupTerminatedEvent(ctx context.Context) error {
 	return m.repo.transaction(ctx, func(ctx context.Context, repo Repository) error {
 		isNotified := false
 		event, ok, err := repo.getJobGroupEvent(ctx, ListJobGroupEventQuery{
@@ -71,34 +71,34 @@ func (m *Manager) sendGroupTerminatedEvent(ctx context.Context) error {
 			return fmt.Errorf("job group %s: %w", event.ID, ErrJobGroupNotFound)
 		}
 
-		ctx = slogctx.With(ctx, "groupId", group.ID, "status", group.Status)
+		ctx = slogctx.With(ctx, "jobGroupId", group.ID, "status", group.Status)
 
-		eventFunc := m.groupEventFunc(group)
+		eventFunc := m.jobGroupEventFunc(group)
 		if eventFunc == nil {
-			slogctx.Debug(ctx, "no group event function set for group status")
+			slogctx.Debug(ctx, "no job group event function set for job group status")
 			return repo.updateJobGroupEvent(ctx, event)
 		}
 
 		err = eventFunc(ctx, group)
 		if err != nil {
-			slogctx.Error(ctx, "failed to send group event", slog.Any("error", err))
+			slogctx.Error(ctx, "failed to send job group event", slog.Any("error", err))
 		}
 		event.IsNotified = err == nil
 		return repo.updateJobGroupEvent(ctx, event)
 	})
 }
 
-// groupEventFunc selects the callback for the group's terminal status, or nil if none is registered.
+// jobGroupEventFunc selects the callback for the job group's terminal status, or nil if none is registered.
 //
 //nolint:exhaustive
-func (m *Manager) groupEventFunc(group JobGroup) GroupTerminatedEventFunc {
+func (m *Manager) jobGroupEventFunc(group JobGroup) JobGroupTerminatedEventFunc {
 	switch group.Status {
-	case GroupStatusDone:
-		return m.groupDoneEventFunc
-	case GroupStatusCanceled:
-		return m.groupCanceledEventFunc
-	case GroupStatusFailed:
-		return m.groupFailedEventFunc
+	case JobGroupStatusDone:
+		return m.jobGroupDoneEventFunc
+	case JobGroupStatusCanceled:
+		return m.jobGroupCanceledEventFunc
+	case JobGroupStatusFailed:
+		return m.jobGroupFailedEventFunc
 	default:
 		return nil
 	}

--- a/jobgroupevent.go
+++ b/jobgroupevent.go
@@ -1,0 +1,105 @@
+package orbital
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/google/uuid"
+
+	slogctx "github.com/veqryn/slog-context"
+)
+
+// JobGroupEvent tracks a pending notification for a job group that reached a terminal state.
+type JobGroupEvent struct {
+	ID         uuid.UUID
+	IsNotified bool
+	UpdatedAt  int64
+	CreatedAt  int64
+}
+
+// GroupTerminatedEventFunc is a callback invoked when a job group reaches a terminal state.
+type GroupTerminatedEventFunc func(ctx context.Context, group JobGroup) error
+
+// recordGroupTerminatedEvent creates or resets a group event record so that
+// sendGroupTerminatedEvent will pick it up for notification.
+// Returns nil immediately if no callback is registered for the group's status.
+func (m *Manager) recordGroupTerminatedEvent(ctx context.Context, repo Repository, group JobGroup) error {
+	eventFunc := m.groupEventFunc(group)
+	if eventFunc == nil {
+		slogctx.Debug(ctx, "no group event function set, skipping event recording")
+		return nil
+	}
+	event, ok, err := repo.getJobGroupEvent(ctx, ListJobGroupEventQuery{ID: group.ID})
+	if err != nil {
+		return err
+	}
+	if !ok {
+		_, err = repo.createJobGroupEvent(ctx, JobGroupEvent{ID: group.ID})
+		return err
+	}
+	if event.IsNotified {
+		event.IsNotified = false
+		return repo.updateJobGroupEvent(ctx, event)
+	}
+	return nil
+}
+
+// sendGroupTerminatedEvent is a background worker that picks up unnotified group events,
+// invokes the registered callback, and marks them as notified on success.
+func (m *Manager) sendGroupTerminatedEvent(ctx context.Context) error {
+	return m.repo.transaction(ctx, func(ctx context.Context, repo Repository) error {
+		isNotified := false
+		event, ok, err := repo.getJobGroupEvent(ctx, ListJobGroupEventQuery{
+			IsNotified:         &isNotified,
+			RetrievalModeQueue: true,
+			OrderByUpdatedAt:   true,
+			Limit:              1,
+		})
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
+
+		group, ok, err := repo.getJobGroup(ctx, event.ID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("job group %s: %w", event.ID, ErrJobGroupNotFound)
+		}
+
+		ctx = slogctx.With(ctx, "groupId", group.ID, "status", group.Status)
+
+		eventFunc := m.groupEventFunc(group)
+		if eventFunc == nil {
+			slogctx.Debug(ctx, "no group event function set for group status")
+			return repo.updateJobGroupEvent(ctx, event)
+		}
+
+		err = eventFunc(ctx, group)
+		if err != nil {
+			slogctx.Error(ctx, "failed to send group event", slog.Any("error", err))
+		}
+		event.IsNotified = err == nil
+		return repo.updateJobGroupEvent(ctx, event)
+	})
+}
+
+// groupEventFunc selects the callback for the group's terminal status, or nil if none is registered.
+//
+//nolint:exhaustive
+func (m *Manager) groupEventFunc(group JobGroup) GroupTerminatedEventFunc {
+	switch group.Status {
+	case GroupStatusDone:
+		return m.groupDoneEventFunc
+	case GroupStatusCanceled:
+		return m.groupCanceledEventFunc
+	case GroupStatusFailed:
+		return m.groupFailedEventFunc
+	default:
+		return nil
+	}
+}

--- a/jobgroupevent_test.go
+++ b/jobgroupevent_test.go
@@ -11,38 +11,38 @@ import (
 	"github.com/openkcm/orbital"
 )
 
-func TestRecordGroupEvent(t *testing.T) {
-	t.Run("should not record group event if group status is not terminal", func(t *testing.T) {
+func TestRecordJobGroupEvent(t *testing.T) {
+	t.Run("should not record job group event if job group status is not terminal", func(t *testing.T) {
 		ctx := t.Context()
 		db, store := createSQLStore(t)
 		defer clearTables(t, db)
 		repo := orbital.NewRepository(store)
 
 		tts := []struct {
-			name        string
-			groupStatus orbital.GroupStatus
+			name           string
+			jobGroupStatus orbital.JobGroupStatus
 		}{
 			{
-				name:        "GroupStatusCreated",
-				groupStatus: orbital.GroupStatusCreated,
+				name:           "JobGroupStatusCreated",
+				jobGroupStatus: orbital.JobGroupStatusCreated,
 			},
 			{
-				name:        "GroupStatusProcessing",
-				groupStatus: orbital.GroupStatusProcessing,
+				name:           "JobGroupStatusProcessing",
+				jobGroupStatus: orbital.JobGroupStatusProcessing,
 			},
 		}
 
 		for _, tt := range tts {
 			t.Run(tt.name, func(t *testing.T) {
 				subj, _ := orbital.NewManager(repo, mockTaskResolveFunc(),
-					orbital.WithGroupDoneEventFunc(mockGroupTerminatedFunc()),
-					orbital.WithGroupFailedEventFunc(mockGroupTerminatedFunc()),
-					orbital.WithGroupCanceledEventFunc(mockGroupTerminatedFunc()),
+					orbital.WithJobGroupDoneEventFunc(mockJobGroupTerminatedFunc()),
+					orbital.WithJobGroupFailedEventFunc(mockJobGroupTerminatedFunc()),
+					orbital.WithJobGroupCanceledEventFunc(mockJobGroupTerminatedFunc()),
 				)
 				groupID := uuid.New()
 
 				// when
-				err := orbital.RecordGroupTerminatedEvent(subj)(ctx, *repo, orbital.JobGroup{ID: groupID, Status: tt.groupStatus})
+				err := orbital.RecordJobGroupTerminatedEvent(subj)(ctx, *repo, orbital.JobGroup{ID: groupID, Status: tt.jobGroupStatus})
 				assert.NoError(t, err)
 
 				// then
@@ -53,47 +53,47 @@ func TestRecordGroupEvent(t *testing.T) {
 		}
 	})
 
-	t.Run("should not record group event if group status is terminal but corresponding eventFunc is nil", func(t *testing.T) {
+	t.Run("should not record job group event if job group status is terminal but corresponding eventFunc is nil", func(t *testing.T) {
 		ctx := t.Context()
 		db, store := createSQLStore(t)
 		defer clearTables(t, db)
 		repo := orbital.NewRepository(store)
 
 		tts := []struct {
-			name                   string
-			groupStatus            orbital.GroupStatus
-			groupDoneEventFunc     orbital.GroupTerminatedEventFunc
-			groupFailedEventFunc   orbital.GroupTerminatedEventFunc
-			groupCanceledEventFunc orbital.GroupTerminatedEventFunc
+			name                      string
+			jobGroupStatus            orbital.JobGroupStatus
+			jobGroupDoneEventFunc     orbital.JobGroupTerminatedEventFunc
+			jobGroupFailedEventFunc   orbital.JobGroupTerminatedEventFunc
+			jobGroupCanceledEventFunc orbital.JobGroupTerminatedEventFunc
 		}{
 			{
-				name:               "GroupStatusDone and groupDoneEventFunc is nil",
-				groupStatus:        orbital.GroupStatusDone,
-				groupDoneEventFunc: nil,
+				name:                  "JobGroupStatusDone and jobGroupDoneEventFunc is nil",
+				jobGroupStatus:        orbital.JobGroupStatusDone,
+				jobGroupDoneEventFunc: nil,
 			},
 			{
-				name:                 "GroupStatusFailed and groupFailedEventFunc is nil",
-				groupStatus:          orbital.GroupStatusFailed,
-				groupFailedEventFunc: nil,
+				name:                    "JobGroupStatusFailed and jobGroupFailedEventFunc is nil",
+				jobGroupStatus:          orbital.JobGroupStatusFailed,
+				jobGroupFailedEventFunc: nil,
 			},
 			{
-				name:                   "GroupStatusCanceled and groupCanceledEventFunc is nil",
-				groupStatus:            orbital.GroupStatusCanceled,
-				groupCanceledEventFunc: nil,
+				name:                      "JobGroupStatusCanceled and jobGroupCanceledEventFunc is nil",
+				jobGroupStatus:            orbital.JobGroupStatusCanceled,
+				jobGroupCanceledEventFunc: nil,
 			},
 		}
 
 		for _, tt := range tts {
 			t.Run(tt.name, func(t *testing.T) {
 				subj, _ := orbital.NewManager(repo, mockTaskResolveFunc(),
-					orbital.WithGroupDoneEventFunc(tt.groupDoneEventFunc),
-					orbital.WithGroupFailedEventFunc(tt.groupFailedEventFunc),
-					orbital.WithGroupCanceledEventFunc(tt.groupCanceledEventFunc),
+					orbital.WithJobGroupDoneEventFunc(tt.jobGroupDoneEventFunc),
+					orbital.WithJobGroupFailedEventFunc(tt.jobGroupFailedEventFunc),
+					orbital.WithJobGroupCanceledEventFunc(tt.jobGroupCanceledEventFunc),
 				)
 				groupID := uuid.New()
 
 				// when
-				err := orbital.RecordGroupTerminatedEvent(subj)(ctx, *repo, orbital.JobGroup{ID: groupID, Status: tt.groupStatus})
+				err := orbital.RecordJobGroupTerminatedEvent(subj)(ctx, *repo, orbital.JobGroup{ID: groupID, Status: tt.jobGroupStatus})
 				assert.NoError(t, err)
 
 				// then
@@ -104,33 +104,33 @@ func TestRecordGroupEvent(t *testing.T) {
 		}
 	})
 
-	t.Run("should record group event if group status is terminal and eventFunc is set", func(t *testing.T) {
+	t.Run("should record job group event if job group status is terminal and eventFunc is set", func(t *testing.T) {
 		ctx := t.Context()
 		db, store := createSQLStore(t)
 		defer clearTables(t, db)
 		repo := orbital.NewRepository(store)
 
 		tts := []struct {
-			name                   string
-			groupStatus            orbital.GroupStatus
-			groupDoneEventFunc     orbital.GroupTerminatedEventFunc
-			groupFailedEventFunc   orbital.GroupTerminatedEventFunc
-			groupCanceledEventFunc orbital.GroupTerminatedEventFunc
+			name                      string
+			jobGroupStatus            orbital.JobGroupStatus
+			jobGroupDoneEventFunc     orbital.JobGroupTerminatedEventFunc
+			jobGroupFailedEventFunc   orbital.JobGroupTerminatedEventFunc
+			jobGroupCanceledEventFunc orbital.JobGroupTerminatedEventFunc
 		}{
 			{
-				name:               "GroupStatusDone",
-				groupStatus:        orbital.GroupStatusDone,
-				groupDoneEventFunc: mockGroupTerminatedFunc(),
+				name:                  "JobGroupStatusDone",
+				jobGroupStatus:        orbital.JobGroupStatusDone,
+				jobGroupDoneEventFunc: mockJobGroupTerminatedFunc(),
 			},
 			{
-				name:                 "GroupStatusFailed",
-				groupStatus:          orbital.GroupStatusFailed,
-				groupFailedEventFunc: mockGroupTerminatedFunc(),
+				name:                    "JobGroupStatusFailed",
+				jobGroupStatus:          orbital.JobGroupStatusFailed,
+				jobGroupFailedEventFunc: mockJobGroupTerminatedFunc(),
 			},
 			{
-				name:                   "GroupStatusCanceled",
-				groupStatus:            orbital.GroupStatusCanceled,
-				groupCanceledEventFunc: mockGroupTerminatedFunc(),
+				name:                      "JobGroupStatusCanceled",
+				jobGroupStatus:            orbital.JobGroupStatusCanceled,
+				jobGroupCanceledEventFunc: mockJobGroupTerminatedFunc(),
 			},
 		}
 
@@ -138,14 +138,14 @@ func TestRecordGroupEvent(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				// given
 				subj, _ := orbital.NewManager(repo, mockTaskResolveFunc(),
-					orbital.WithGroupDoneEventFunc(tt.groupDoneEventFunc),
-					orbital.WithGroupFailedEventFunc(tt.groupFailedEventFunc),
-					orbital.WithGroupCanceledEventFunc(tt.groupCanceledEventFunc),
+					orbital.WithJobGroupDoneEventFunc(tt.jobGroupDoneEventFunc),
+					orbital.WithJobGroupFailedEventFunc(tt.jobGroupFailedEventFunc),
+					orbital.WithJobGroupCanceledEventFunc(tt.jobGroupCanceledEventFunc),
 				)
 				groupID := uuid.New()
 
 				// when
-				err := orbital.RecordGroupTerminatedEvent(subj)(ctx, *repo, orbital.JobGroup{ID: groupID, Status: tt.groupStatus})
+				err := orbital.RecordJobGroupTerminatedEvent(subj)(ctx, *repo, orbital.JobGroup{ID: groupID, Status: tt.jobGroupStatus})
 				assert.NoError(t, err)
 
 				// then
@@ -158,33 +158,33 @@ func TestRecordGroupEvent(t *testing.T) {
 		}
 	})
 
-	t.Run("should set group event isNotified to false when existing event has isNotified as true", func(t *testing.T) {
+	t.Run("should set job group event isNotified to false when existing event has isNotified as true", func(t *testing.T) {
 		ctx := t.Context()
 		db, store := createSQLStore(t)
 		defer clearTables(t, db)
 		repo := orbital.NewRepository(store)
 
 		tts := []struct {
-			name                   string
-			groupStatus            orbital.GroupStatus
-			groupDoneEventFunc     orbital.GroupTerminatedEventFunc
-			groupFailedEventFunc   orbital.GroupTerminatedEventFunc
-			groupCanceledEventFunc orbital.GroupTerminatedEventFunc
+			name                      string
+			jobGroupStatus            orbital.JobGroupStatus
+			jobGroupDoneEventFunc     orbital.JobGroupTerminatedEventFunc
+			jobGroupFailedEventFunc   orbital.JobGroupTerminatedEventFunc
+			jobGroupCanceledEventFunc orbital.JobGroupTerminatedEventFunc
 		}{
 			{
-				name:               "for GroupStatusDone",
-				groupStatus:        orbital.GroupStatusDone,
-				groupDoneEventFunc: mockGroupTerminatedFunc(),
+				name:                  "for JobGroupStatusDone",
+				jobGroupStatus:        orbital.JobGroupStatusDone,
+				jobGroupDoneEventFunc: mockJobGroupTerminatedFunc(),
 			},
 			{
-				name:                 "for GroupStatusFailed",
-				groupStatus:          orbital.GroupStatusFailed,
-				groupFailedEventFunc: mockGroupTerminatedFunc(),
+				name:                    "for JobGroupStatusFailed",
+				jobGroupStatus:          orbital.JobGroupStatusFailed,
+				jobGroupFailedEventFunc: mockJobGroupTerminatedFunc(),
 			},
 			{
-				name:                   "for GroupStatusCanceled",
-				groupStatus:            orbital.GroupStatusCanceled,
-				groupCanceledEventFunc: mockGroupTerminatedFunc(),
+				name:                      "for JobGroupStatusCanceled",
+				jobGroupStatus:            orbital.JobGroupStatusCanceled,
+				jobGroupCanceledEventFunc: mockJobGroupTerminatedFunc(),
 			},
 		}
 
@@ -192,18 +192,18 @@ func TestRecordGroupEvent(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				// given
 				subj, _ := orbital.NewManager(repo, mockTaskResolveFunc(),
-					orbital.WithGroupDoneEventFunc(tt.groupDoneEventFunc),
-					orbital.WithGroupFailedEventFunc(tt.groupFailedEventFunc),
-					orbital.WithGroupCanceledEventFunc(tt.groupCanceledEventFunc),
+					orbital.WithJobGroupDoneEventFunc(tt.jobGroupDoneEventFunc),
+					orbital.WithJobGroupFailedEventFunc(tt.jobGroupFailedEventFunc),
+					orbital.WithJobGroupCanceledEventFunc(tt.jobGroupCanceledEventFunc),
 				)
 				groupID := uuid.New()
 
-				// create a group event with isNotified = true
+				// create a job group event with isNotified = true
 				_, err := orbital.CreateJobGroupEvent(repo)(ctx, orbital.JobGroupEvent{ID: groupID, IsNotified: true})
 				assert.NoError(t, err)
 
 				// when
-				err = orbital.RecordGroupTerminatedEvent(subj)(ctx, *repo, orbital.JobGroup{ID: groupID, Status: tt.groupStatus})
+				err = orbital.RecordJobGroupTerminatedEvent(subj)(ctx, *repo, orbital.JobGroup{ID: groupID, Status: tt.jobGroupStatus})
 				assert.NoError(t, err)
 
 				// then
@@ -224,16 +224,16 @@ func TestRecordGroupEvent(t *testing.T) {
 
 		// given
 		subj, _ := orbital.NewManager(repo, mockTaskResolveFunc(),
-			orbital.WithGroupDoneEventFunc(mockGroupTerminatedFunc()),
+			orbital.WithJobGroupDoneEventFunc(mockJobGroupTerminatedFunc()),
 		)
 		groupID := uuid.New()
 
-		// create a group event with isNotified = false
+		// create a job group event with isNotified = false
 		createdEvent, err := orbital.CreateJobGroupEvent(repo)(ctx, orbital.JobGroupEvent{ID: groupID, IsNotified: false})
 		assert.NoError(t, err)
 
 		// when
-		err = orbital.RecordGroupTerminatedEvent(subj)(ctx, *repo, orbital.JobGroup{ID: groupID, Status: orbital.GroupStatusDone})
+		err = orbital.RecordJobGroupTerminatedEvent(subj)(ctx, *repo, orbital.JobGroup{ID: groupID, Status: orbital.JobGroupStatusDone})
 		assert.NoError(t, err)
 
 		// then
@@ -246,8 +246,8 @@ func TestRecordGroupEvent(t *testing.T) {
 	})
 }
 
-func TestSendGroupEvent(t *testing.T) {
-	t.Run("should not send event if there are no group events", func(t *testing.T) {
+func TestSendJobGroupEvent(t *testing.T) {
+	t.Run("should not send event if there are no job group events", func(t *testing.T) {
 		// given
 		ctx := t.Context()
 		db, store := createSQLStore(t)
@@ -256,17 +256,17 @@ func TestSendGroupEvent(t *testing.T) {
 
 		groupTerminationCalled := 0
 		subj, _ := orbital.NewManager(repo, mockTaskResolveFunc(),
-			orbital.WithGroupDoneEventFunc(
+			orbital.WithJobGroupDoneEventFunc(
 				func(_ context.Context, _ orbital.JobGroup) error {
 					groupTerminationCalled++
 					return nil
 				}),
-			orbital.WithGroupCanceledEventFunc(
+			orbital.WithJobGroupCanceledEventFunc(
 				func(_ context.Context, _ orbital.JobGroup) error {
 					groupTerminationCalled++
 					return nil
 				}),
-			orbital.WithGroupFailedEventFunc(
+			orbital.WithJobGroupFailedEventFunc(
 				func(_ context.Context, _ orbital.JobGroup) error {
 					groupTerminationCalled++
 					return nil
@@ -274,14 +274,14 @@ func TestSendGroupEvent(t *testing.T) {
 		)
 
 		// when
-		err := orbital.SendGroupTerminatedEvent(subj)(ctx)
+		err := orbital.SendJobGroupTerminatedEvent(subj)(ctx)
 
 		// then
 		assert.NoError(t, err)
 		assert.Equal(t, 0, groupTerminationCalled)
 	})
 
-	t.Run("should return error if there is no group for the group event", func(t *testing.T) {
+	t.Run("should return error if there is no job group for the job group event", func(t *testing.T) {
 		// given
 		ctx := t.Context()
 		db, store := createSQLStore(t)
@@ -292,7 +292,7 @@ func TestSendGroupEvent(t *testing.T) {
 		subj, _ := orbital.NewManager(repo, mockTaskResolveFunc())
 
 		// when
-		err = orbital.SendGroupTerminatedEvent(subj)(ctx)
+		err = orbital.SendJobGroupTerminatedEvent(subj)(ctx)
 
 		// then
 		assert.Error(t, err)
@@ -305,73 +305,73 @@ func TestSendGroupEvent(t *testing.T) {
 		repo := orbital.NewRepository(store)
 
 		tts := []struct {
-			name                          string
-			groupStatus                   orbital.GroupStatus
-			expCallGroupDoneEventFunc     int
-			expCallGroupFailedEventFunc   int
-			expCallGroupCanceledEventFunc int
+			name                             string
+			jobGroupStatus                   orbital.JobGroupStatus
+			expCallJobGroupDoneEventFunc     int
+			expCallJobGroupFailedEventFunc   int
+			expCallJobGroupCanceledEventFunc int
 		}{
 			{
-				name:                      "GroupStatusDone",
-				groupStatus:               orbital.GroupStatusDone,
-				expCallGroupDoneEventFunc: 1,
+				name:                         "JobGroupStatusDone",
+				jobGroupStatus:               orbital.JobGroupStatusDone,
+				expCallJobGroupDoneEventFunc: 1,
 			},
 			{
-				name:                        "GroupStatusFailed",
-				groupStatus:                 orbital.GroupStatusFailed,
-				expCallGroupFailedEventFunc: 1,
+				name:                           "JobGroupStatusFailed",
+				jobGroupStatus:                 orbital.JobGroupStatusFailed,
+				expCallJobGroupFailedEventFunc: 1,
 			},
 			{
-				name:                          "GroupStatusCanceled",
-				groupStatus:                   orbital.GroupStatusCanceled,
-				expCallGroupCanceledEventFunc: 1,
+				name:                             "JobGroupStatusCanceled",
+				jobGroupStatus:                   orbital.JobGroupStatusCanceled,
+				expCallJobGroupCanceledEventFunc: 1,
 			},
 		}
 		for _, tt := range tts {
 			t.Run(tt.name, func(t *testing.T) {
 				// given
 				createdGroup, err := orbital.CreateJobGroup(repo)(ctx, orbital.JobGroup{
-					Type:   "test-group",
-					Status: tt.groupStatus,
+					Type:   "test-job-group",
+					Status: tt.jobGroupStatus,
 				})
 				assert.NoError(t, err)
 
 				_, err = orbital.CreateJobGroupEvent(repo)(ctx, orbital.JobGroupEvent{ID: createdGroup.ID, IsNotified: false})
 				assert.NoError(t, err)
 
-				var actCallGroupDoneEventFunc, actCallGroupFailedEventFunc, actCallGroupCanceledEventFunc int
+				var actCallJobGroupDoneEventFunc, actCallJobGroupFailedEventFunc, actCallJobGroupCanceledEventFunc int
 				subj, _ := orbital.NewManager(repo, mockTaskResolveFunc(),
-					orbital.WithGroupDoneEventFunc(
+					orbital.WithJobGroupDoneEventFunc(
 						func(_ context.Context, group orbital.JobGroup) error {
-							actCallGroupDoneEventFunc++
+							actCallJobGroupDoneEventFunc++
 							assert.Equal(t, createdGroup.ID, group.ID)
-							assert.Equal(t, tt.groupStatus, group.Status)
+							assert.Equal(t, tt.jobGroupStatus, group.Status)
 							return nil
 						}),
-					orbital.WithGroupCanceledEventFunc(
+					orbital.WithJobGroupCanceledEventFunc(
 						func(_ context.Context, group orbital.JobGroup) error {
-							actCallGroupCanceledEventFunc++
+							actCallJobGroupCanceledEventFunc++
 							assert.Equal(t, createdGroup.ID, group.ID)
-							assert.Equal(t, tt.groupStatus, group.Status)
+							assert.Equal(t, tt.jobGroupStatus, group.Status)
 							return nil
 						}),
-					orbital.WithGroupFailedEventFunc(
+					orbital.WithJobGroupFailedEventFunc(
 						func(_ context.Context, group orbital.JobGroup) error {
-							actCallGroupFailedEventFunc++
+							actCallJobGroupFailedEventFunc++
 							assert.Equal(t, createdGroup.ID, group.ID)
-							assert.Equal(t, tt.groupStatus, group.Status)
+							assert.Equal(t, tt.jobGroupStatus, group.Status)
 							return nil
 						}),
 				)
 
 				// when
-				err = orbital.SendGroupTerminatedEvent(subj)(ctx)
+				err = orbital.SendJobGroupTerminatedEvent(subj)(ctx)
 
 				// then
 				assert.NoError(t, err)
-				assert.Equal(t, tt.expCallGroupDoneEventFunc, actCallGroupDoneEventFunc)
-				assert.Equal(t, tt.expCallGroupFailedEventFunc, actCallGroupFailedEventFunc)
-				assert.Equal(t, tt.expCallGroupCanceledEventFunc, actCallGroupCanceledEventFunc)
+				assert.Equal(t, tt.expCallJobGroupDoneEventFunc, actCallJobGroupDoneEventFunc)
+				assert.Equal(t, tt.expCallJobGroupFailedEventFunc, actCallJobGroupFailedEventFunc)
+				assert.Equal(t, tt.expCallJobGroupCanceledEventFunc, actCallJobGroupCanceledEventFunc)
 
 				actEvent, ok, err := orbital.GetJobGroupEvent(repo)(ctx, orbital.ListJobGroupEventQuery{ID: createdGroup.ID})
 				assert.NoError(t, err)
@@ -390,28 +390,28 @@ func TestSendGroupEvent(t *testing.T) {
 		repo := orbital.NewRepository(store)
 
 		tts := []struct {
-			name        string
-			groupStatus orbital.GroupStatus
+			name           string
+			jobGroupStatus orbital.JobGroupStatus
 		}{
 			{
-				name:        "GroupStatusDone",
-				groupStatus: orbital.GroupStatusDone,
+				name:           "JobGroupStatusDone",
+				jobGroupStatus: orbital.JobGroupStatusDone,
 			},
 			{
-				name:        "GroupStatusFailed",
-				groupStatus: orbital.GroupStatusFailed,
+				name:           "JobGroupStatusFailed",
+				jobGroupStatus: orbital.JobGroupStatusFailed,
 			},
 			{
-				name:        "GroupStatusCanceled",
-				groupStatus: orbital.GroupStatusCanceled,
+				name:           "JobGroupStatusCanceled",
+				jobGroupStatus: orbital.JobGroupStatusCanceled,
 			},
 		}
 		for _, tt := range tts {
 			t.Run(tt.name, func(t *testing.T) {
 				// given
 				createdGroup, err := orbital.CreateJobGroup(repo)(ctx, orbital.JobGroup{
-					Type:   "test-group",
-					Status: tt.groupStatus,
+					Type:   "test-job-group",
+					Status: tt.jobGroupStatus,
 				})
 				assert.NoError(t, err)
 
@@ -419,17 +419,17 @@ func TestSendGroupEvent(t *testing.T) {
 				assert.NoError(t, err)
 
 				subj, _ := orbital.NewManager(repo, mockTaskResolveFunc(),
-					orbital.WithGroupDoneEventFunc(
+					orbital.WithJobGroupDoneEventFunc(
 						func(_ context.Context, group orbital.JobGroup) error {
 							assert.Equal(t, createdGroup.ID, group.ID)
 							return assert.AnError
 						}),
-					orbital.WithGroupCanceledEventFunc(
+					orbital.WithJobGroupCanceledEventFunc(
 						func(_ context.Context, group orbital.JobGroup) error {
 							assert.Equal(t, createdGroup.ID, group.ID)
 							return assert.AnError
 						}),
-					orbital.WithGroupFailedEventFunc(
+					orbital.WithJobGroupFailedEventFunc(
 						func(_ context.Context, group orbital.JobGroup) error {
 							assert.Equal(t, createdGroup.ID, group.ID)
 							return assert.AnError
@@ -438,7 +438,7 @@ func TestSendGroupEvent(t *testing.T) {
 
 				// when
 				time.Sleep(1 * time.Microsecond) // ensure the updatedAt will change
-				err = orbital.SendGroupTerminatedEvent(subj)(ctx)
+				err = orbital.SendJobGroupTerminatedEvent(subj)(ctx)
 
 				// then
 				assert.NoError(t, err)
@@ -460,40 +460,40 @@ func TestSendGroupEvent(t *testing.T) {
 		repo := orbital.NewRepository(store)
 
 		tts := []struct {
-			name                   string
-			groupStatus            orbital.GroupStatus
-			groupDoneEventFunc     orbital.GroupTerminatedEventFunc
-			groupFailedEventFunc   orbital.GroupTerminatedEventFunc
-			groupCanceledEventFunc orbital.GroupTerminatedEventFunc
+			name                      string
+			jobGroupStatus            orbital.JobGroupStatus
+			jobGroupDoneEventFunc     orbital.JobGroupTerminatedEventFunc
+			jobGroupFailedEventFunc   orbital.JobGroupTerminatedEventFunc
+			jobGroupCanceledEventFunc orbital.JobGroupTerminatedEventFunc
 		}{
 			{
-				name:                   "GroupStatusDone",
-				groupStatus:            orbital.GroupStatusDone,
-				groupDoneEventFunc:     nil,
-				groupCanceledEventFunc: mockGroupTerminatedFunc(),
-				groupFailedEventFunc:   mockGroupTerminatedFunc(),
+				name:                      "JobGroupStatusDone",
+				jobGroupStatus:            orbital.JobGroupStatusDone,
+				jobGroupDoneEventFunc:     nil,
+				jobGroupCanceledEventFunc: mockJobGroupTerminatedFunc(),
+				jobGroupFailedEventFunc:   mockJobGroupTerminatedFunc(),
 			},
 			{
-				name:                   "GroupStatusFailed",
-				groupStatus:            orbital.GroupStatusFailed,
-				groupFailedEventFunc:   nil,
-				groupDoneEventFunc:     mockGroupTerminatedFunc(),
-				groupCanceledEventFunc: mockGroupTerminatedFunc(),
+				name:                      "JobGroupStatusFailed",
+				jobGroupStatus:            orbital.JobGroupStatusFailed,
+				jobGroupFailedEventFunc:   nil,
+				jobGroupDoneEventFunc:     mockJobGroupTerminatedFunc(),
+				jobGroupCanceledEventFunc: mockJobGroupTerminatedFunc(),
 			},
 			{
-				name:                   "GroupStatusCanceled",
-				groupStatus:            orbital.GroupStatusCanceled,
-				groupCanceledEventFunc: nil,
-				groupDoneEventFunc:     mockGroupTerminatedFunc(),
-				groupFailedEventFunc:   mockGroupTerminatedFunc(),
+				name:                      "JobGroupStatusCanceled",
+				jobGroupStatus:            orbital.JobGroupStatusCanceled,
+				jobGroupCanceledEventFunc: nil,
+				jobGroupDoneEventFunc:     mockJobGroupTerminatedFunc(),
+				jobGroupFailedEventFunc:   mockJobGroupTerminatedFunc(),
 			},
 		}
 		for _, tt := range tts {
 			t.Run(tt.name, func(t *testing.T) {
 				// given
 				createdGroup, err := orbital.CreateJobGroup(repo)(ctx, orbital.JobGroup{
-					Type:   "test-group",
-					Status: tt.groupStatus,
+					Type:   "test-job-group",
+					Status: tt.jobGroupStatus,
 				})
 				assert.NoError(t, err)
 
@@ -507,28 +507,28 @@ func TestSendGroupEvent(t *testing.T) {
 				}
 
 				// override non-nil funcs with counting versions
-				doneFunc := tt.groupDoneEventFunc
+				doneFunc := tt.jobGroupDoneEventFunc
 				if doneFunc != nil {
 					doneFunc = countingFunc
 				}
-				failedFunc := tt.groupFailedEventFunc
+				failedFunc := tt.jobGroupFailedEventFunc
 				if failedFunc != nil {
 					failedFunc = countingFunc
 				}
-				canceledFunc := tt.groupCanceledEventFunc
+				canceledFunc := tt.jobGroupCanceledEventFunc
 				if canceledFunc != nil {
 					canceledFunc = countingFunc
 				}
 
 				subj, _ := orbital.NewManager(repo, mockTaskResolveFunc(),
-					orbital.WithGroupDoneEventFunc(doneFunc),
-					orbital.WithGroupCanceledEventFunc(canceledFunc),
-					orbital.WithGroupFailedEventFunc(failedFunc),
+					orbital.WithJobGroupDoneEventFunc(doneFunc),
+					orbital.WithJobGroupCanceledEventFunc(canceledFunc),
+					orbital.WithJobGroupFailedEventFunc(failedFunc),
 				)
 
 				// when
 				time.Sleep(1 * time.Microsecond) // ensure the updatedAt will change
-				err = orbital.SendGroupTerminatedEvent(subj)(ctx)
+				err = orbital.SendJobGroupTerminatedEvent(subj)(ctx)
 
 				// then
 				assert.NoError(t, err)

--- a/jobgroupevent_test.go
+++ b/jobgroupevent_test.go
@@ -1,0 +1,547 @@
+package orbital_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openkcm/orbital"
+)
+
+func TestRecordGroupEvent(t *testing.T) {
+	t.Run("should not record group event if group status is not terminal", func(t *testing.T) {
+		ctx := t.Context()
+		db, store := createSQLStore(t)
+		defer clearTables(t, db)
+		repo := orbital.NewRepository(store)
+
+		tts := []struct {
+			name        string
+			groupStatus orbital.GroupStatus
+		}{
+			{
+				name:        "GroupStatusCreated",
+				groupStatus: orbital.GroupStatusCreated,
+			},
+			{
+				name:        "GroupStatusProcessing",
+				groupStatus: orbital.GroupStatusProcessing,
+			},
+		}
+
+		for _, tt := range tts {
+			t.Run(tt.name, func(t *testing.T) {
+				subj, _ := orbital.NewManager(repo, mockTaskResolveFunc(),
+					orbital.WithGroupDoneEventFunc(mockGroupTerminatedFunc()),
+					orbital.WithGroupFailedEventFunc(mockGroupTerminatedFunc()),
+					orbital.WithGroupCanceledEventFunc(mockGroupTerminatedFunc()),
+				)
+				groupID := uuid.New()
+
+				// when
+				err := orbital.RecordGroupTerminatedEvent(subj)(ctx, *repo, orbital.JobGroup{ID: groupID, Status: tt.groupStatus})
+				assert.NoError(t, err)
+
+				// then
+				_, ok, err := orbital.GetJobGroupEvent(repo)(ctx, orbital.ListJobGroupEventQuery{ID: groupID})
+				assert.NoError(t, err)
+				assert.False(t, ok)
+			})
+		}
+	})
+
+	t.Run("should not record group event if group status is terminal but corresponding eventFunc is nil", func(t *testing.T) {
+		ctx := t.Context()
+		db, store := createSQLStore(t)
+		defer clearTables(t, db)
+		repo := orbital.NewRepository(store)
+
+		tts := []struct {
+			name                   string
+			groupStatus            orbital.GroupStatus
+			groupDoneEventFunc     orbital.GroupTerminatedEventFunc
+			groupFailedEventFunc   orbital.GroupTerminatedEventFunc
+			groupCanceledEventFunc orbital.GroupTerminatedEventFunc
+		}{
+			{
+				name:               "GroupStatusDone and groupDoneEventFunc is nil",
+				groupStatus:        orbital.GroupStatusDone,
+				groupDoneEventFunc: nil,
+			},
+			{
+				name:                 "GroupStatusFailed and groupFailedEventFunc is nil",
+				groupStatus:          orbital.GroupStatusFailed,
+				groupFailedEventFunc: nil,
+			},
+			{
+				name:                   "GroupStatusCanceled and groupCanceledEventFunc is nil",
+				groupStatus:            orbital.GroupStatusCanceled,
+				groupCanceledEventFunc: nil,
+			},
+		}
+
+		for _, tt := range tts {
+			t.Run(tt.name, func(t *testing.T) {
+				subj, _ := orbital.NewManager(repo, mockTaskResolveFunc(),
+					orbital.WithGroupDoneEventFunc(tt.groupDoneEventFunc),
+					orbital.WithGroupFailedEventFunc(tt.groupFailedEventFunc),
+					orbital.WithGroupCanceledEventFunc(tt.groupCanceledEventFunc),
+				)
+				groupID := uuid.New()
+
+				// when
+				err := orbital.RecordGroupTerminatedEvent(subj)(ctx, *repo, orbital.JobGroup{ID: groupID, Status: tt.groupStatus})
+				assert.NoError(t, err)
+
+				// then
+				_, ok, err := orbital.GetJobGroupEvent(repo)(ctx, orbital.ListJobGroupEventQuery{ID: groupID})
+				assert.NoError(t, err)
+				assert.False(t, ok)
+			})
+		}
+	})
+
+	t.Run("should record group event if group status is terminal and eventFunc is set", func(t *testing.T) {
+		ctx := t.Context()
+		db, store := createSQLStore(t)
+		defer clearTables(t, db)
+		repo := orbital.NewRepository(store)
+
+		tts := []struct {
+			name                   string
+			groupStatus            orbital.GroupStatus
+			groupDoneEventFunc     orbital.GroupTerminatedEventFunc
+			groupFailedEventFunc   orbital.GroupTerminatedEventFunc
+			groupCanceledEventFunc orbital.GroupTerminatedEventFunc
+		}{
+			{
+				name:               "GroupStatusDone",
+				groupStatus:        orbital.GroupStatusDone,
+				groupDoneEventFunc: mockGroupTerminatedFunc(),
+			},
+			{
+				name:                 "GroupStatusFailed",
+				groupStatus:          orbital.GroupStatusFailed,
+				groupFailedEventFunc: mockGroupTerminatedFunc(),
+			},
+			{
+				name:                   "GroupStatusCanceled",
+				groupStatus:            orbital.GroupStatusCanceled,
+				groupCanceledEventFunc: mockGroupTerminatedFunc(),
+			},
+		}
+
+		for _, tt := range tts {
+			t.Run(tt.name, func(t *testing.T) {
+				// given
+				subj, _ := orbital.NewManager(repo, mockTaskResolveFunc(),
+					orbital.WithGroupDoneEventFunc(tt.groupDoneEventFunc),
+					orbital.WithGroupFailedEventFunc(tt.groupFailedEventFunc),
+					orbital.WithGroupCanceledEventFunc(tt.groupCanceledEventFunc),
+				)
+				groupID := uuid.New()
+
+				// when
+				err := orbital.RecordGroupTerminatedEvent(subj)(ctx, *repo, orbital.JobGroup{ID: groupID, Status: tt.groupStatus})
+				assert.NoError(t, err)
+
+				// then
+				event, ok, err := orbital.GetJobGroupEvent(repo)(ctx, orbital.ListJobGroupEventQuery{ID: groupID})
+				assert.NoError(t, err)
+				assert.True(t, ok)
+				assert.Equal(t, groupID, event.ID)
+				assert.False(t, event.IsNotified)
+			})
+		}
+	})
+
+	t.Run("should set group event isNotified to false when existing event has isNotified as true", func(t *testing.T) {
+		ctx := t.Context()
+		db, store := createSQLStore(t)
+		defer clearTables(t, db)
+		repo := orbital.NewRepository(store)
+
+		tts := []struct {
+			name                   string
+			groupStatus            orbital.GroupStatus
+			groupDoneEventFunc     orbital.GroupTerminatedEventFunc
+			groupFailedEventFunc   orbital.GroupTerminatedEventFunc
+			groupCanceledEventFunc orbital.GroupTerminatedEventFunc
+		}{
+			{
+				name:               "for GroupStatusDone",
+				groupStatus:        orbital.GroupStatusDone,
+				groupDoneEventFunc: mockGroupTerminatedFunc(),
+			},
+			{
+				name:                 "for GroupStatusFailed",
+				groupStatus:          orbital.GroupStatusFailed,
+				groupFailedEventFunc: mockGroupTerminatedFunc(),
+			},
+			{
+				name:                   "for GroupStatusCanceled",
+				groupStatus:            orbital.GroupStatusCanceled,
+				groupCanceledEventFunc: mockGroupTerminatedFunc(),
+			},
+		}
+
+		for _, tt := range tts {
+			t.Run(tt.name, func(t *testing.T) {
+				// given
+				subj, _ := orbital.NewManager(repo, mockTaskResolveFunc(),
+					orbital.WithGroupDoneEventFunc(tt.groupDoneEventFunc),
+					orbital.WithGroupFailedEventFunc(tt.groupFailedEventFunc),
+					orbital.WithGroupCanceledEventFunc(tt.groupCanceledEventFunc),
+				)
+				groupID := uuid.New()
+
+				// create a group event with isNotified = true
+				_, err := orbital.CreateJobGroupEvent(repo)(ctx, orbital.JobGroupEvent{ID: groupID, IsNotified: true})
+				assert.NoError(t, err)
+
+				// when
+				err = orbital.RecordGroupTerminatedEvent(subj)(ctx, *repo, orbital.JobGroup{ID: groupID, Status: tt.groupStatus})
+				assert.NoError(t, err)
+
+				// then
+				event, ok, err := orbital.GetJobGroupEvent(repo)(ctx, orbital.ListJobGroupEventQuery{ID: groupID})
+				assert.NoError(t, err)
+				assert.True(t, ok)
+				assert.Equal(t, groupID, event.ID)
+				assert.False(t, event.IsNotified)
+			})
+		}
+	})
+
+	t.Run("should not modify event if it already exists with isNotified as false", func(t *testing.T) {
+		ctx := t.Context()
+		db, store := createSQLStore(t)
+		defer clearTables(t, db)
+		repo := orbital.NewRepository(store)
+
+		// given
+		subj, _ := orbital.NewManager(repo, mockTaskResolveFunc(),
+			orbital.WithGroupDoneEventFunc(mockGroupTerminatedFunc()),
+		)
+		groupID := uuid.New()
+
+		// create a group event with isNotified = false
+		createdEvent, err := orbital.CreateJobGroupEvent(repo)(ctx, orbital.JobGroupEvent{ID: groupID, IsNotified: false})
+		assert.NoError(t, err)
+
+		// when
+		err = orbital.RecordGroupTerminatedEvent(subj)(ctx, *repo, orbital.JobGroup{ID: groupID, Status: orbital.GroupStatusDone})
+		assert.NoError(t, err)
+
+		// then
+		event, ok, err := orbital.GetJobGroupEvent(repo)(ctx, orbital.ListJobGroupEventQuery{ID: groupID})
+		assert.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, groupID, event.ID)
+		assert.False(t, event.IsNotified)
+		assert.Equal(t, createdEvent.UpdatedAt, event.UpdatedAt)
+	})
+}
+
+func TestSendGroupEvent(t *testing.T) {
+	t.Run("should not send event if there are no group events", func(t *testing.T) {
+		// given
+		ctx := t.Context()
+		db, store := createSQLStore(t)
+		defer clearTables(t, db)
+		repo := orbital.NewRepository(store)
+
+		groupTerminationCalled := 0
+		subj, _ := orbital.NewManager(repo, mockTaskResolveFunc(),
+			orbital.WithGroupDoneEventFunc(
+				func(_ context.Context, _ orbital.JobGroup) error {
+					groupTerminationCalled++
+					return nil
+				}),
+			orbital.WithGroupCanceledEventFunc(
+				func(_ context.Context, _ orbital.JobGroup) error {
+					groupTerminationCalled++
+					return nil
+				}),
+			orbital.WithGroupFailedEventFunc(
+				func(_ context.Context, _ orbital.JobGroup) error {
+					groupTerminationCalled++
+					return nil
+				}),
+		)
+
+		// when
+		err := orbital.SendGroupTerminatedEvent(subj)(ctx)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, 0, groupTerminationCalled)
+	})
+
+	t.Run("should return error if there is no group for the group event", func(t *testing.T) {
+		// given
+		ctx := t.Context()
+		db, store := createSQLStore(t)
+		defer clearTables(t, db)
+		repo := orbital.NewRepository(store)
+		_, err := orbital.CreateJobGroupEvent(repo)(ctx, orbital.JobGroupEvent{IsNotified: false})
+		assert.NoError(t, err)
+		subj, _ := orbital.NewManager(repo, mockTaskResolveFunc())
+
+		// when
+		err = orbital.SendGroupTerminatedEvent(subj)(ctx)
+
+		// then
+		assert.Error(t, err)
+	})
+
+	t.Run("should invoke the correct callback and mark event as notified", func(t *testing.T) {
+		ctx := t.Context()
+		db, store := createSQLStore(t)
+		defer clearTables(t, db)
+		repo := orbital.NewRepository(store)
+
+		tts := []struct {
+			name                          string
+			groupStatus                   orbital.GroupStatus
+			expCallGroupDoneEventFunc     int
+			expCallGroupFailedEventFunc   int
+			expCallGroupCanceledEventFunc int
+		}{
+			{
+				name:                      "GroupStatusDone",
+				groupStatus:               orbital.GroupStatusDone,
+				expCallGroupDoneEventFunc: 1,
+			},
+			{
+				name:                        "GroupStatusFailed",
+				groupStatus:                 orbital.GroupStatusFailed,
+				expCallGroupFailedEventFunc: 1,
+			},
+			{
+				name:                          "GroupStatusCanceled",
+				groupStatus:                   orbital.GroupStatusCanceled,
+				expCallGroupCanceledEventFunc: 1,
+			},
+		}
+		for _, tt := range tts {
+			t.Run(tt.name, func(t *testing.T) {
+				// given
+				createdGroup, err := orbital.CreateJobGroup(repo)(ctx, orbital.JobGroup{
+					Type:   "test-group",
+					Status: tt.groupStatus,
+				})
+				assert.NoError(t, err)
+
+				_, err = orbital.CreateJobGroupEvent(repo)(ctx, orbital.JobGroupEvent{ID: createdGroup.ID, IsNotified: false})
+				assert.NoError(t, err)
+
+				var actCallGroupDoneEventFunc, actCallGroupFailedEventFunc, actCallGroupCanceledEventFunc int
+				subj, _ := orbital.NewManager(repo, mockTaskResolveFunc(),
+					orbital.WithGroupDoneEventFunc(
+						func(_ context.Context, group orbital.JobGroup) error {
+							actCallGroupDoneEventFunc++
+							assert.Equal(t, createdGroup.ID, group.ID)
+							assert.Equal(t, tt.groupStatus, group.Status)
+							return nil
+						}),
+					orbital.WithGroupCanceledEventFunc(
+						func(_ context.Context, group orbital.JobGroup) error {
+							actCallGroupCanceledEventFunc++
+							assert.Equal(t, createdGroup.ID, group.ID)
+							assert.Equal(t, tt.groupStatus, group.Status)
+							return nil
+						}),
+					orbital.WithGroupFailedEventFunc(
+						func(_ context.Context, group orbital.JobGroup) error {
+							actCallGroupFailedEventFunc++
+							assert.Equal(t, createdGroup.ID, group.ID)
+							assert.Equal(t, tt.groupStatus, group.Status)
+							return nil
+						}),
+				)
+
+				// when
+				err = orbital.SendGroupTerminatedEvent(subj)(ctx)
+
+				// then
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expCallGroupDoneEventFunc, actCallGroupDoneEventFunc)
+				assert.Equal(t, tt.expCallGroupFailedEventFunc, actCallGroupFailedEventFunc)
+				assert.Equal(t, tt.expCallGroupCanceledEventFunc, actCallGroupCanceledEventFunc)
+
+				actEvent, ok, err := orbital.GetJobGroupEvent(repo)(ctx, orbital.ListJobGroupEventQuery{ID: createdGroup.ID})
+				assert.NoError(t, err)
+				assert.True(t, ok)
+				assert.True(t, actEvent.IsNotified)
+				assert.NoError(t, clearJobGroupEventsTable(ctx, db))
+				assert.NoError(t, clearJobGroupsTable(ctx, db))
+			})
+		}
+	})
+
+	t.Run("should not mark as notified and should bump updatedAt if event func returns an error", func(t *testing.T) {
+		ctx := t.Context()
+		db, store := createSQLStore(t)
+		defer clearTables(t, db)
+		repo := orbital.NewRepository(store)
+
+		tts := []struct {
+			name        string
+			groupStatus orbital.GroupStatus
+		}{
+			{
+				name:        "GroupStatusDone",
+				groupStatus: orbital.GroupStatusDone,
+			},
+			{
+				name:        "GroupStatusFailed",
+				groupStatus: orbital.GroupStatusFailed,
+			},
+			{
+				name:        "GroupStatusCanceled",
+				groupStatus: orbital.GroupStatusCanceled,
+			},
+		}
+		for _, tt := range tts {
+			t.Run(tt.name, func(t *testing.T) {
+				// given
+				createdGroup, err := orbital.CreateJobGroup(repo)(ctx, orbital.JobGroup{
+					Type:   "test-group",
+					Status: tt.groupStatus,
+				})
+				assert.NoError(t, err)
+
+				createdEvent, err := orbital.CreateJobGroupEvent(repo)(ctx, orbital.JobGroupEvent{ID: createdGroup.ID, IsNotified: false})
+				assert.NoError(t, err)
+
+				subj, _ := orbital.NewManager(repo, mockTaskResolveFunc(),
+					orbital.WithGroupDoneEventFunc(
+						func(_ context.Context, group orbital.JobGroup) error {
+							assert.Equal(t, createdGroup.ID, group.ID)
+							return assert.AnError
+						}),
+					orbital.WithGroupCanceledEventFunc(
+						func(_ context.Context, group orbital.JobGroup) error {
+							assert.Equal(t, createdGroup.ID, group.ID)
+							return assert.AnError
+						}),
+					orbital.WithGroupFailedEventFunc(
+						func(_ context.Context, group orbital.JobGroup) error {
+							assert.Equal(t, createdGroup.ID, group.ID)
+							return assert.AnError
+						}),
+				)
+
+				// when
+				time.Sleep(1 * time.Microsecond) // ensure the updatedAt will change
+				err = orbital.SendGroupTerminatedEvent(subj)(ctx)
+
+				// then
+				assert.NoError(t, err)
+				actEvent, ok, err := orbital.GetJobGroupEvent(repo)(ctx, orbital.ListJobGroupEventQuery{ID: createdGroup.ID})
+				assert.NoError(t, err)
+				assert.True(t, ok)
+				assert.False(t, actEvent.IsNotified)
+				assert.Less(t, createdEvent.UpdatedAt, actEvent.UpdatedAt)
+				assert.NoError(t, clearJobGroupEventsTable(ctx, db))
+				assert.NoError(t, clearJobGroupsTable(ctx, db))
+			})
+		}
+	})
+
+	t.Run("should not call callback and should bump updatedAt if no event func is configured for the status", func(t *testing.T) {
+		ctx := t.Context()
+		db, store := createSQLStore(t)
+		defer clearTables(t, db)
+		repo := orbital.NewRepository(store)
+
+		tts := []struct {
+			name                   string
+			groupStatus            orbital.GroupStatus
+			groupDoneEventFunc     orbital.GroupTerminatedEventFunc
+			groupFailedEventFunc   orbital.GroupTerminatedEventFunc
+			groupCanceledEventFunc orbital.GroupTerminatedEventFunc
+		}{
+			{
+				name:                   "GroupStatusDone",
+				groupStatus:            orbital.GroupStatusDone,
+				groupDoneEventFunc:     nil,
+				groupCanceledEventFunc: mockGroupTerminatedFunc(),
+				groupFailedEventFunc:   mockGroupTerminatedFunc(),
+			},
+			{
+				name:                   "GroupStatusFailed",
+				groupStatus:            orbital.GroupStatusFailed,
+				groupFailedEventFunc:   nil,
+				groupDoneEventFunc:     mockGroupTerminatedFunc(),
+				groupCanceledEventFunc: mockGroupTerminatedFunc(),
+			},
+			{
+				name:                   "GroupStatusCanceled",
+				groupStatus:            orbital.GroupStatusCanceled,
+				groupCanceledEventFunc: nil,
+				groupDoneEventFunc:     mockGroupTerminatedFunc(),
+				groupFailedEventFunc:   mockGroupTerminatedFunc(),
+			},
+		}
+		for _, tt := range tts {
+			t.Run(tt.name, func(t *testing.T) {
+				// given
+				createdGroup, err := orbital.CreateJobGroup(repo)(ctx, orbital.JobGroup{
+					Type:   "test-group",
+					Status: tt.groupStatus,
+				})
+				assert.NoError(t, err)
+
+				createdEvent, err := orbital.CreateJobGroupEvent(repo)(ctx, orbital.JobGroupEvent{ID: createdGroup.ID, IsNotified: false})
+				assert.NoError(t, err)
+
+				callbackCalled := 0
+				countingFunc := func(_ context.Context, _ orbital.JobGroup) error {
+					callbackCalled++
+					return nil
+				}
+
+				// override non-nil funcs with counting versions
+				doneFunc := tt.groupDoneEventFunc
+				if doneFunc != nil {
+					doneFunc = countingFunc
+				}
+				failedFunc := tt.groupFailedEventFunc
+				if failedFunc != nil {
+					failedFunc = countingFunc
+				}
+				canceledFunc := tt.groupCanceledEventFunc
+				if canceledFunc != nil {
+					canceledFunc = countingFunc
+				}
+
+				subj, _ := orbital.NewManager(repo, mockTaskResolveFunc(),
+					orbital.WithGroupDoneEventFunc(doneFunc),
+					orbital.WithGroupCanceledEventFunc(canceledFunc),
+					orbital.WithGroupFailedEventFunc(failedFunc),
+				)
+
+				// when
+				time.Sleep(1 * time.Microsecond) // ensure the updatedAt will change
+				err = orbital.SendGroupTerminatedEvent(subj)(ctx)
+
+				// then
+				assert.NoError(t, err)
+				assert.Equal(t, 0, callbackCalled)
+
+				actEvent, ok, err := orbital.GetJobGroupEvent(repo)(ctx, orbital.ListJobGroupEventQuery{ID: createdGroup.ID})
+				assert.NoError(t, err)
+				assert.True(t, ok)
+				assert.False(t, actEvent.IsNotified)
+				assert.Less(t, createdEvent.UpdatedAt, actEvent.UpdatedAt)
+				assert.NoError(t, clearJobGroupEventsTable(ctx, db))
+				assert.NoError(t, clearJobGroupsTable(ctx, db))
+			})
+		}
+	})
+}

--- a/labels_test.go
+++ b/labels_test.go
@@ -31,7 +31,7 @@ func TestLabels_Validate(t *testing.T) {
 		},
 		{
 			name:      "should fail with orbital/ prefix",
-			labels:    orbital.Labels{"orbital/group-id": "123"},
+			labels:    orbital.Labels{"orbital/job-group-id": "123"},
 			expectErr: true,
 		},
 		{
@@ -142,8 +142,8 @@ func TestJob_WithLabels(t *testing.T) {
 
 func TestLabelConstants(t *testing.T) {
 	assert.Equal(t, "orbital/", orbital.LabelPrefixReserved)
-	assert.Equal(t, "orbital/group-id", orbital.LabelKeyGroupID)
-	assert.Equal(t, "orbital/group-order-key", orbital.LabelKeyGroupOrderKey)
+	assert.Equal(t, "orbital/job-group-id", orbital.LabelKeyJobGroupID)
+	assert.Equal(t, "orbital/job-group-order-key", orbital.LabelKeyJobGroupOrderKey)
 }
 
 func TestMergeLabels(t *testing.T) {

--- a/manager.go
+++ b/manager.go
@@ -31,14 +31,17 @@ type (
 		runner     *worker.Runner
 		closeOnce  sync.Once
 
-		Config               Config
-		repo                 *Repository
-		jobConfirmFunc       JobConfirmFunc
-		taskResolveFunc      TaskResolveFunc
-		jobDoneEventFunc     JobTerminatedEventFunc
-		jobCanceledEventFunc JobTerminatedEventFunc
-		jobFailedEventFunc   JobTerminatedEventFunc
-		targets              map[string]TargetManager
+		Config                 Config
+		repo                   *Repository
+		jobConfirmFunc         JobConfirmFunc
+		taskResolveFunc        TaskResolveFunc
+		jobDoneEventFunc       JobTerminatedEventFunc
+		jobCanceledEventFunc   JobTerminatedEventFunc
+		jobFailedEventFunc     JobTerminatedEventFunc
+		groupDoneEventFunc     GroupTerminatedEventFunc
+		groupCanceledEventFunc GroupTerminatedEventFunc
+		groupFailedEventFunc   GroupTerminatedEventFunc
+		targets                map[string]TargetManager
 	}
 
 	// JobTerminatedEventFunc defines a callback function type for sending job events.
@@ -61,6 +64,8 @@ type (
 		ReconcileWorkerConfig WorkerConfig
 		// NotifyWorkerConfig holds the configuration for the notification worker.
 		NotifyWorkerConfig WorkerConfig
+		// NotifyGroupWorkerConfig holds the configuration for the group notification worker.
+		NotifyGroupWorkerConfig WorkerConfig
 		// ScheduleJobGroupWorkerConfig holds the configuration for the job group scheduling worker.
 		ScheduleJobGroupWorkerConfig WorkerConfig
 		// BackoffBaseIntervalSec is the base interval for exponential backoff in seconds.
@@ -142,6 +147,11 @@ func NewManager(repo *Repository, taskResolver TaskResolveFunc, optFuncs ...Mana
 				ExecInterval: defWorkExecInterval,
 				Timeout:      defWorkTimeout,
 			},
+			NotifyGroupWorkerConfig: WorkerConfig{
+				NoOfWorkers:  defNoOfWorker,
+				ExecInterval: defWorkExecInterval,
+				Timeout:      defWorkTimeout,
+			},
 			ConfirmJobAfter:        defConfirmJobAfter,
 			TaskLimitNum:           defTaskLimitNum,
 			BackoffBaseIntervalSec: defBackoffBaseInterval,
@@ -195,6 +205,27 @@ func WithJobFailedEventFunc(f JobTerminatedEventFunc) ManagerOptsFunc {
 	}
 }
 
+// WithGroupDoneEventFunc registers a function to send group done events.
+func WithGroupDoneEventFunc(f GroupTerminatedEventFunc) ManagerOptsFunc {
+	return func(m *Manager) {
+		m.groupDoneEventFunc = f
+	}
+}
+
+// WithGroupCanceledEventFunc registers a function to send group canceled events.
+func WithGroupCanceledEventFunc(f GroupTerminatedEventFunc) ManagerOptsFunc {
+	return func(m *Manager) {
+		m.groupCanceledEventFunc = f
+	}
+}
+
+// WithGroupFailedEventFunc registers a function to send group failed events.
+func WithGroupFailedEventFunc(f GroupTerminatedEventFunc) ManagerOptsFunc {
+	return func(m *Manager) {
+		m.groupFailedEventFunc = f
+	}
+}
+
 // Start starts the job manager to process jobs.
 func (m *Manager) Start(ctx context.Context) error {
 	if !m.isValidConfig(ctx) {
@@ -241,6 +272,13 @@ func (m *Manager) Start(ctx context.Context) error {
 				ExecInterval: m.Config.ScheduleJobGroupWorkerConfig.ExecInterval,
 				NoOfWorkers:  m.Config.ScheduleJobGroupWorkerConfig.NoOfWorkers,
 				Timeout:      m.Config.ScheduleJobGroupWorkerConfig.Timeout,
+			},
+			{
+				Name:         "notify-group-event",
+				Fn:           m.sendGroupTerminatedEvent,
+				ExecInterval: m.Config.NotifyGroupWorkerConfig.ExecInterval,
+				NoOfWorkers:  m.Config.NotifyGroupWorkerConfig.NoOfWorkers,
+				Timeout:      m.Config.NotifyGroupWorkerConfig.Timeout,
 			},
 		},
 	}
@@ -434,7 +472,9 @@ func (m *Manager) GetJobGroup(ctx context.Context, groupID uuid.UUID) (JobGroup,
 // Returns ErrJobGroupNotFound or ErrJobGroupUnCancelable if already terminal.
 func (m *Manager) CancelJobGroup(ctx context.Context, groupID uuid.UUID) error {
 	return m.repo.transaction(ctx, func(ctx context.Context, repo Repository) error {
-		slogctx.Debug(ctx, "canceling job group", "groupId", groupID)
+		ctx = slogctx.With(ctx, "groupId", groupID)
+		slogctx.Debug(ctx, "canceling job group")
+
 		group, found, err := repo.getJobGroupForUpdate(ctx, groupID)
 		if err != nil {
 			return err
@@ -448,7 +488,13 @@ func (m *Manager) CancelJobGroup(ctx context.Context, groupID uuid.UUID) error {
 
 		group.Status = GroupStatusCanceled
 		group.ErrorMessage = "group has been canceled by the user"
-		return repo.updateJobGroup(ctx, group)
+		ctx = slogctx.With(ctx, "status", group.Status)
+
+		if err := repo.updateJobGroup(ctx, group); err != nil {
+			return err
+		}
+
+		return m.recordGroupTerminatedEvent(ctx, repo, group)
 	})
 }
 
@@ -469,13 +515,21 @@ func (m *Manager) scheduleJobGroup(ctx context.Context) error {
 		}
 
 		group := groups[0]
+		ctx = slogctx.With(ctx, "groupId", group.ID)
 
 		jobs, err := repo.listOrderedGroupJobs(ctx, group.ID)
 		if err != nil {
 			return err
 		}
 
-		return evaluateJobs(jobs).apply(ctx, repo, &group)
+		if err := evaluateJobs(jobs).apply(ctx, repo, &group); err != nil {
+			return err
+		}
+		if group.isTerminal() {
+			ctx = slogctx.With(ctx, "status", group.Status)
+			return m.recordGroupTerminatedEvent(ctx, repo, group)
+		}
+		return nil
 	})
 }
 

--- a/manager.go
+++ b/manager.go
@@ -31,17 +31,17 @@ type (
 		runner     *worker.Runner
 		closeOnce  sync.Once
 
-		Config                 Config
-		repo                   *Repository
-		jobConfirmFunc         JobConfirmFunc
-		taskResolveFunc        TaskResolveFunc
-		jobDoneEventFunc       JobTerminatedEventFunc
-		jobCanceledEventFunc   JobTerminatedEventFunc
-		jobFailedEventFunc     JobTerminatedEventFunc
-		groupDoneEventFunc     GroupTerminatedEventFunc
-		groupCanceledEventFunc GroupTerminatedEventFunc
-		groupFailedEventFunc   GroupTerminatedEventFunc
-		targets                map[string]TargetManager
+		Config                    Config
+		repo                      *Repository
+		jobConfirmFunc            JobConfirmFunc
+		taskResolveFunc           TaskResolveFunc
+		jobDoneEventFunc          JobTerminatedEventFunc
+		jobCanceledEventFunc      JobTerminatedEventFunc
+		jobFailedEventFunc        JobTerminatedEventFunc
+		jobGroupDoneEventFunc     JobGroupTerminatedEventFunc
+		jobGroupCanceledEventFunc JobGroupTerminatedEventFunc
+		jobGroupFailedEventFunc   JobGroupTerminatedEventFunc
+		targets                   map[string]TargetManager
 	}
 
 	// JobTerminatedEventFunc defines a callback function type for sending job events.
@@ -64,8 +64,8 @@ type (
 		ReconcileWorkerConfig WorkerConfig
 		// NotifyWorkerConfig holds the configuration for the notification worker.
 		NotifyWorkerConfig WorkerConfig
-		// NotifyGroupWorkerConfig holds the configuration for the group notification worker.
-		NotifyGroupWorkerConfig WorkerConfig
+		// NotifyJobGroupWorkerConfig holds the configuration for the job group notification worker.
+		NotifyJobGroupWorkerConfig WorkerConfig
 		// ScheduleJobGroupWorkerConfig holds the configuration for the job group scheduling worker.
 		ScheduleJobGroupWorkerConfig WorkerConfig
 		// BackoffBaseIntervalSec is the base interval for exponential backoff in seconds.
@@ -147,7 +147,7 @@ func NewManager(repo *Repository, taskResolver TaskResolveFunc, optFuncs ...Mana
 				ExecInterval: defWorkExecInterval,
 				Timeout:      defWorkTimeout,
 			},
-			NotifyGroupWorkerConfig: WorkerConfig{
+			NotifyJobGroupWorkerConfig: WorkerConfig{
 				NoOfWorkers:  defNoOfWorker,
 				ExecInterval: defWorkExecInterval,
 				Timeout:      defWorkTimeout,
@@ -205,24 +205,24 @@ func WithJobFailedEventFunc(f JobTerminatedEventFunc) ManagerOptsFunc {
 	}
 }
 
-// WithGroupDoneEventFunc registers a function to send group done events.
-func WithGroupDoneEventFunc(f GroupTerminatedEventFunc) ManagerOptsFunc {
+// WithJobGroupDoneEventFunc registers a function to send job group done events.
+func WithJobGroupDoneEventFunc(f JobGroupTerminatedEventFunc) ManagerOptsFunc {
 	return func(m *Manager) {
-		m.groupDoneEventFunc = f
+		m.jobGroupDoneEventFunc = f
 	}
 }
 
-// WithGroupCanceledEventFunc registers a function to send group canceled events.
-func WithGroupCanceledEventFunc(f GroupTerminatedEventFunc) ManagerOptsFunc {
+// WithJobGroupCanceledEventFunc registers a function to send job group canceled events.
+func WithJobGroupCanceledEventFunc(f JobGroupTerminatedEventFunc) ManagerOptsFunc {
 	return func(m *Manager) {
-		m.groupCanceledEventFunc = f
+		m.jobGroupCanceledEventFunc = f
 	}
 }
 
-// WithGroupFailedEventFunc registers a function to send group failed events.
-func WithGroupFailedEventFunc(f GroupTerminatedEventFunc) ManagerOptsFunc {
+// WithJobGroupFailedEventFunc registers a function to send job group failed events.
+func WithJobGroupFailedEventFunc(f JobGroupTerminatedEventFunc) ManagerOptsFunc {
 	return func(m *Manager) {
-		m.groupFailedEventFunc = f
+		m.jobGroupFailedEventFunc = f
 	}
 }
 
@@ -274,11 +274,11 @@ func (m *Manager) Start(ctx context.Context) error {
 				Timeout:      m.Config.ScheduleJobGroupWorkerConfig.Timeout,
 			},
 			{
-				Name:         "notify-group-event",
-				Fn:           m.sendGroupTerminatedEvent,
-				ExecInterval: m.Config.NotifyGroupWorkerConfig.ExecInterval,
-				NoOfWorkers:  m.Config.NotifyGroupWorkerConfig.NoOfWorkers,
-				Timeout:      m.Config.NotifyGroupWorkerConfig.Timeout,
+				Name:         "notify-job-group-event",
+				Fn:           m.sendJobGroupTerminatedEvent,
+				ExecInterval: m.Config.NotifyJobGroupWorkerConfig.ExecInterval,
+				NoOfWorkers:  m.Config.NotifyJobGroupWorkerConfig.NoOfWorkers,
+				Timeout:      m.Config.NotifyJobGroupWorkerConfig.Timeout,
 			},
 		},
 	}
@@ -392,7 +392,7 @@ func (m *Manager) CancelJob(ctx context.Context, jobID uuid.UUID) error {
 }
 
 // PrepareJobGroup creates a job group and all its jobs in a single transaction.
-// All jobs are created with SCHEDULED status and the group is created with CREATED status.
+// All jobs are created with SCHEDULED status and the job group is created with CREATED status.
 // Returns an error if no jobs are provided or if any labels validation fails.
 func (m *Manager) PrepareJobGroup(ctx context.Context, group JobGroup) (JobGroup, error) {
 	if len(group.Jobs) == 0 {
@@ -409,7 +409,7 @@ func (m *Manager) PrepareJobGroup(ctx context.Context, group JobGroup) (JobGroup
 		}
 	}
 
-	group.Status = GroupStatusCreated
+	group.Status = JobGroupStatusCreated
 	jobs := group.Jobs
 
 	var err error
@@ -422,8 +422,8 @@ func (m *Manager) PrepareJobGroup(ctx context.Context, group JobGroup) (JobGroup
 		createdJobs := make([]Job, 0, len(jobs))
 		for i, job := range jobs {
 			job.Labels = mergeLabels(job.Labels, Labels{
-				LabelKeyGroupID:       group.ID.String(),
-				LabelKeyGroupOrderKey: strconv.Itoa(i),
+				LabelKeyJobGroupID:       group.ID.String(),
+				LabelKeyJobGroupOrderKey: strconv.Itoa(i),
 			})
 			job.Status = JobStatusScheduled
 
@@ -447,7 +447,7 @@ func (m *Manager) PrepareJobGroup(ctx context.Context, group JobGroup) (JobGroup
 }
 
 // GetJobGroup retrieves a job group by its ID along with all its jobs.
-// Returns (group, true, nil) if found, or (empty, false, nil) if not found.
+// Returns (job group, true, nil) if found, or (empty, false, nil) if not found.
 // Returns an error if a repository or sorting operation fails.
 func (m *Manager) GetJobGroup(ctx context.Context, groupID uuid.UUID) (JobGroup, bool, error) {
 	group, found, err := m.repo.getJobGroup(ctx, groupID)
@@ -472,7 +472,7 @@ func (m *Manager) GetJobGroup(ctx context.Context, groupID uuid.UUID) (JobGroup,
 // Returns ErrJobGroupNotFound or ErrJobGroupUnCancelable if already terminal.
 func (m *Manager) CancelJobGroup(ctx context.Context, groupID uuid.UUID) error {
 	return m.repo.transaction(ctx, func(ctx context.Context, repo Repository) error {
-		ctx = slogctx.With(ctx, "groupId", groupID)
+		ctx = slogctx.With(ctx, "jobGroupId", groupID)
 		slogctx.Debug(ctx, "canceling job group")
 
 		group, found, err := repo.getJobGroupForUpdate(ctx, groupID)
@@ -486,23 +486,23 @@ func (m *Manager) CancelJobGroup(ctx context.Context, groupID uuid.UUID) error {
 			return ErrJobGroupUnCancelable
 		}
 
-		group.Status = GroupStatusCanceled
-		group.ErrorMessage = "group has been canceled by the user"
+		group.Status = JobGroupStatusCanceled
+		group.ErrorMessage = "job group has been canceled by the user"
 		ctx = slogctx.With(ctx, "status", group.Status)
 
 		if err := repo.updateJobGroup(ctx, group); err != nil {
 			return err
 		}
 
-		return m.recordGroupTerminatedEvent(ctx, repo, group)
+		return m.recordJobGroupTerminatedEvent(ctx, repo, group)
 	})
 }
 
-// scheduleJobGroup manages sequential job execution within groups.
+// scheduleJobGroup manages sequential job execution within job groups.
 func (m *Manager) scheduleJobGroup(ctx context.Context) error {
 	return m.repo.transaction(ctx, func(ctx context.Context, repo Repository) error {
 		groups, err := repo.listJobGroups(ctx, ListJobGroupsQuery{
-			StatusIn:           []GroupStatus{GroupStatusCreated, GroupStatusProcessing},
+			StatusIn:           []JobGroupStatus{JobGroupStatusCreated, JobGroupStatusProcessing},
 			Limit:              1,
 			RetrievalModeQueue: true,
 			OrderByUpdatedAt:   true,
@@ -515,7 +515,7 @@ func (m *Manager) scheduleJobGroup(ctx context.Context) error {
 		}
 
 		group := groups[0]
-		ctx = slogctx.With(ctx, "groupId", group.ID)
+		ctx = slogctx.With(ctx, "jobGroupId", group.ID)
 
 		jobs, err := repo.listOrderedGroupJobs(ctx, group.ID)
 		if err != nil {
@@ -525,9 +525,9 @@ func (m *Manager) scheduleJobGroup(ctx context.Context) error {
 		if err := evaluateJobs(jobs).apply(ctx, repo, &group); err != nil {
 			return err
 		}
-		if group.isTerminal() {
+		if group.hasTerminalState() {
 			ctx = slogctx.With(ctx, "status", group.Status)
-			return m.recordGroupTerminatedEvent(ctx, repo, group)
+			return m.recordJobGroupTerminatedEvent(ctx, repo, group)
 		}
 		return nil
 	})

--- a/manager_test.go
+++ b/manager_test.go
@@ -217,7 +217,7 @@ func TestPrepareJob(t *testing.T) {
 			prepJob: orbital.Job{
 				Type:       "type",
 				ExternalID: "ext-id-reserved",
-				Labels:     orbital.Labels{"orbital/group-id": "123"},
+				Labels:     orbital.Labels{"orbital/job-group-id": "123"},
 			},
 			expErr: orbital.ErrReservedLabelPrefix,
 		},
@@ -1530,7 +1530,7 @@ func TestPrepareJobGroup(t *testing.T) {
 			},
 			expGroup: orbital.JobGroup{
 				Type:   "batch-sync",
-				Status: orbital.GroupStatusCreated,
+				Status: orbital.JobGroupStatusCreated,
 				Labels: orbital.Labels{"env": "prod"},
 				Jobs: []orbital.Job{
 					{Type: "job-type", Status: orbital.JobStatusScheduled},
@@ -1541,7 +1541,7 @@ func TestPrepareJobGroup(t *testing.T) {
 			expErr: nil,
 		},
 		{
-			name: "should merge user labels with group labels on jobs",
+			name: "should merge user labels with job group labels on jobs",
 			group: orbital.JobGroup{
 				Type: "batch-sync",
 				Jobs: []orbital.Job{
@@ -1550,7 +1550,7 @@ func TestPrepareJobGroup(t *testing.T) {
 			},
 			expGroup: orbital.JobGroup{
 				Type:   "batch-sync",
-				Status: orbital.GroupStatusCreated,
+				Status: orbital.JobGroupStatusCreated,
 				Jobs: []orbital.Job{
 					{Type: "job-type", Status: orbital.JobStatusScheduled, Labels: orbital.Labels{"user-key": "user-value"}},
 				},
@@ -1566,7 +1566,7 @@ func TestPrepareJobGroup(t *testing.T) {
 			expErr: orbital.ErrJobGroupEmpty,
 		},
 		{
-			name: "should return error when group labels have reserved prefix",
+			name: "should return error when job group labels have reserved prefix",
 			group: orbital.JobGroup{
 				Type:   "batch-sync",
 				Labels: orbital.Labels{"orbital/custom": "value"},
@@ -1626,8 +1626,8 @@ func TestPrepareJobGroup(t *testing.T) {
 				assert.NotZero(t, job.UpdatedAt)
 				assert.Equal(t, tt.expGroup.Jobs[i].Type, job.Type)
 				assert.Equal(t, tt.expGroup.Jobs[i].Status, job.Status)
-				assert.Equal(t, result.ID.String(), job.Labels[orbital.LabelKeyGroupID])
-				assert.Equal(t, strconv.Itoa(i), job.Labels[orbital.LabelKeyGroupOrderKey])
+				assert.Equal(t, result.ID.String(), job.Labels[orbital.LabelKeyJobGroupID])
+				assert.Equal(t, strconv.Itoa(i), job.Labels[orbital.LabelKeyJobGroupOrderKey])
 				// verify user-provided labels are preserved
 				for k, v := range tt.expGroup.Jobs[i].Labels {
 					assert.Equal(t, v, job.Labels[k])
@@ -1671,17 +1671,17 @@ func TestGetJobGroup(t *testing.T) {
 		assert.True(t, found)
 		assert.Equal(t, created.ID, result.ID)
 		assert.Equal(t, "batch-sync", result.Type)
-		assert.Equal(t, orbital.GroupStatusCreated, result.Status)
+		assert.Equal(t, orbital.JobGroupStatusCreated, result.Status)
 		assert.Equal(t, orbital.Labels{"env": "prod"}, result.Labels)
 
 		assert.Len(t, result.Jobs, 3)
 		for i, job := range result.Jobs {
-			assert.Equal(t, strconv.Itoa(i), job.Labels[orbital.LabelKeyGroupOrderKey])
+			assert.Equal(t, strconv.Itoa(i), job.Labels[orbital.LabelKeyJobGroupOrderKey])
 			assert.Equal(t, created.Jobs[i].ID, job.ID)
 		}
 	})
 
-	t.Run("should return not found for non-existent group", func(t *testing.T) {
+	t.Run("should return not found for non-existent job group", func(t *testing.T) {
 		// given
 		db, store := createSQLStore(t)
 		defer clearTables(t, db)
@@ -1716,56 +1716,56 @@ func (t TaskResolveUnknown) Type() orbital.TaskResolverResultType {
 
 func TestScheduleJobGroup(t *testing.T) {
 	tests := []struct {
-		name           string
-		groupStatus    orbital.GroupStatus
-		jobStatuses    [2]orbital.JobStatus
-		expGroupStatus orbital.GroupStatus
-		expJobStatuses [2]orbital.JobStatus
-		expErrContains string
+		name              string
+		jobGroupStatus    orbital.JobGroupStatus
+		jobStatuses       [2]orbital.JobStatus
+		expJobGroupStatus orbital.JobGroupStatus
+		expJobStatuses    [2]orbital.JobStatus
+		expErrContains    string
 	}{
 		{
-			name:           "promotes first job when group is CREATED",
-			groupStatus:    orbital.GroupStatusCreated,
-			jobStatuses:    [2]orbital.JobStatus{orbital.JobStatusScheduled, orbital.JobStatusScheduled},
-			expGroupStatus: orbital.GroupStatusProcessing,
-			expJobStatuses: [2]orbital.JobStatus{orbital.JobStatusCreated, orbital.JobStatusScheduled},
+			name:              "promotes first job when job group is CREATED",
+			jobGroupStatus:    orbital.JobGroupStatusCreated,
+			jobStatuses:       [2]orbital.JobStatus{orbital.JobStatusScheduled, orbital.JobStatusScheduled},
+			expJobGroupStatus: orbital.JobGroupStatusProcessing,
+			expJobStatuses:    [2]orbital.JobStatus{orbital.JobStatusCreated, orbital.JobStatusScheduled},
 		},
 		{
-			name:           "promotes next job when previous is done",
-			groupStatus:    orbital.GroupStatusProcessing,
-			jobStatuses:    [2]orbital.JobStatus{orbital.JobStatusDone, orbital.JobStatusScheduled},
-			expGroupStatus: orbital.GroupStatusProcessing,
-			expJobStatuses: [2]orbital.JobStatus{orbital.JobStatusDone, orbital.JobStatusCreated},
+			name:              "promotes next job when previous is done",
+			jobGroupStatus:    orbital.JobGroupStatusProcessing,
+			jobStatuses:       [2]orbital.JobStatus{orbital.JobStatusDone, orbital.JobStatusScheduled},
+			expJobGroupStatus: orbital.JobGroupStatusProcessing,
+			expJobStatuses:    [2]orbital.JobStatus{orbital.JobStatusDone, orbital.JobStatusCreated},
 		},
 		{
-			name:           "completes group when all jobs are done",
-			groupStatus:    orbital.GroupStatusProcessing,
-			jobStatuses:    [2]orbital.JobStatus{orbital.JobStatusDone, orbital.JobStatusDone},
-			expGroupStatus: orbital.GroupStatusDone,
-			expJobStatuses: [2]orbital.JobStatus{orbital.JobStatusDone, orbital.JobStatusDone},
+			name:              "completes job group when all jobs are done",
+			jobGroupStatus:    orbital.JobGroupStatusProcessing,
+			jobStatuses:       [2]orbital.JobStatus{orbital.JobStatusDone, orbital.JobStatusDone},
+			expJobGroupStatus: orbital.JobGroupStatusDone,
+			expJobStatuses:    [2]orbital.JobStatus{orbital.JobStatusDone, orbital.JobStatusDone},
 		},
 		{
-			name:           "fails group when a job fails",
-			groupStatus:    orbital.GroupStatusProcessing,
-			jobStatuses:    [2]orbital.JobStatus{orbital.JobStatusDone, orbital.JobStatusFailed},
-			expGroupStatus: orbital.GroupStatusFailed,
-			expJobStatuses: [2]orbital.JobStatus{orbital.JobStatusDone, orbital.JobStatusFailed},
-			expErrContains: "failed",
+			name:              "fails job group when a job fails",
+			jobGroupStatus:    orbital.JobGroupStatusProcessing,
+			jobStatuses:       [2]orbital.JobStatus{orbital.JobStatusDone, orbital.JobStatusFailed},
+			expJobGroupStatus: orbital.JobGroupStatusFailed,
+			expJobStatuses:    [2]orbital.JobStatus{orbital.JobStatusDone, orbital.JobStatusFailed},
+			expErrContains:    "failed",
 		},
 		{
-			name:           "fails group when first job fails, second job stays scheduled without promotion",
-			groupStatus:    orbital.GroupStatusProcessing,
-			jobStatuses:    [2]orbital.JobStatus{orbital.JobStatusFailed, orbital.JobStatusScheduled},
-			expGroupStatus: orbital.GroupStatusFailed,
-			expJobStatuses: [2]orbital.JobStatus{orbital.JobStatusFailed, orbital.JobStatusScheduled},
-			expErrContains: "failed",
+			name:              "fails job group when first job fails, second job stays scheduled without promotion",
+			jobGroupStatus:    orbital.JobGroupStatusProcessing,
+			jobStatuses:       [2]orbital.JobStatus{orbital.JobStatusFailed, orbital.JobStatusScheduled},
+			expJobGroupStatus: orbital.JobGroupStatusFailed,
+			expJobStatuses:    [2]orbital.JobStatus{orbital.JobStatusFailed, orbital.JobStatusScheduled},
+			expErrContains:    "failed",
 		},
 		{
-			name:           "waits when a job is active",
-			groupStatus:    orbital.GroupStatusProcessing,
-			jobStatuses:    [2]orbital.JobStatus{orbital.JobStatusProcessing, orbital.JobStatusScheduled},
-			expGroupStatus: orbital.GroupStatusProcessing,
-			expJobStatuses: [2]orbital.JobStatus{orbital.JobStatusProcessing, orbital.JobStatusScheduled},
+			name:              "waits when a job is active",
+			jobGroupStatus:    orbital.JobGroupStatusProcessing,
+			jobStatuses:       [2]orbital.JobStatus{orbital.JobStatusProcessing, orbital.JobStatusScheduled},
+			expJobGroupStatus: orbital.JobGroupStatusProcessing,
+			expJobStatuses:    [2]orbital.JobStatus{orbital.JobStatusProcessing, orbital.JobStatusScheduled},
 		},
 	}
 
@@ -1795,7 +1795,7 @@ func TestScheduleJobGroup(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			group.Status = tt.groupStatus
+			group.Status = tt.jobGroupStatus
 			err = orbital.UpdateJobGroup(repo)(ctx, group)
 			assert.NoError(t, err)
 
@@ -1813,7 +1813,7 @@ func TestScheduleJobGroup(t *testing.T) {
 			result, found, err := subj.GetJobGroup(ctx, group.ID)
 			assert.NoError(t, err)
 			assert.True(t, found)
-			assert.Equal(t, tt.expGroupStatus, result.Status)
+			assert.Equal(t, tt.expJobGroupStatus, result.Status)
 			assert.Greater(t, result.UpdatedAt, before.UpdatedAt)
 
 			for i, expStatus := range tt.expJobStatuses {
@@ -1826,7 +1826,7 @@ func TestScheduleJobGroup(t *testing.T) {
 		})
 	}
 
-	t.Run("no-op when no groups to process", func(t *testing.T) {
+	t.Run("no-op when no job groups to process", func(t *testing.T) {
 		db, store := createSQLStore(t)
 		defer clearTables(t, db)
 		repo := orbital.NewRepository(store)
@@ -1838,7 +1838,7 @@ func TestScheduleJobGroup(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("skips terminal groups", func(t *testing.T) {
+	t.Run("skips terminal job groups", func(t *testing.T) {
 		db, store := createSQLStore(t)
 		defer clearTables(t, db)
 		repo := orbital.NewRepository(store)
@@ -1848,35 +1848,35 @@ func TestScheduleJobGroup(t *testing.T) {
 
 		ctx := t.Context()
 
-		// Create a DONE group
+		// Create a DONE job group
 		doneGroup, err := subj.PrepareJobGroup(ctx, orbital.JobGroup{
-			Type: "done-group",
+			Type: "done-job-group",
 			Jobs: []orbital.Job{
 				{Type: "job-type", Data: []byte("job-1")},
 				{Type: "job-type", Data: []byte("job-2")},
 			},
 		})
 		assert.NoError(t, err)
-		doneGroup.Status = orbital.GroupStatusDone
+		doneGroup.Status = orbital.JobGroupStatusDone
 		err = orbital.UpdateJobGroup(repo)(ctx, doneGroup)
 		assert.NoError(t, err)
 
-		// Create a FAILED group
+		// Create a FAILED job group
 		failedGroup, err := subj.PrepareJobGroup(ctx, orbital.JobGroup{
-			Type: "failed-group",
+			Type: "failed-job-group",
 			Jobs: []orbital.Job{
 				{Type: "job-type", Data: []byte("job-1")},
 				{Type: "job-type", Data: []byte("job-2")},
 			},
 		})
 		assert.NoError(t, err)
-		failedGroup.Status = orbital.GroupStatusFailed
+		failedGroup.Status = orbital.JobGroupStatusFailed
 		err = orbital.UpdateJobGroup(repo)(ctx, failedGroup)
 		assert.NoError(t, err)
 
-		// Create a CREATED group (control — should be picked up)
+		// Create a CREATED job group (control — should be picked up)
 		activeGroup, err := subj.PrepareJobGroup(ctx, orbital.JobGroup{
-			Type: "active-group",
+			Type: "active-job-group",
 			Jobs: []orbital.Job{
 				{Type: "job-type", Data: []byte("job-1")},
 				{Type: "job-type", Data: []byte("job-2")},
@@ -1888,30 +1888,30 @@ func TestScheduleJobGroup(t *testing.T) {
 		err = orbital.ScheduleJobGroup(subj)(ctx)
 		assert.NoError(t, err)
 
-		// then - terminal groups untouched
+		// then - terminal job groups untouched
 		result, _, err := subj.GetJobGroup(ctx, doneGroup.ID)
 		assert.NoError(t, err)
-		assert.Equal(t, orbital.GroupStatusDone, result.Status)
+		assert.Equal(t, orbital.JobGroupStatusDone, result.Status)
 		assert.Equal(t, orbital.JobStatusScheduled, result.Jobs[0].Status)
 		assert.Equal(t, orbital.JobStatusScheduled, result.Jobs[1].Status)
 
 		result, _, err = subj.GetJobGroup(ctx, failedGroup.ID)
 		assert.NoError(t, err)
-		assert.Equal(t, orbital.GroupStatusFailed, result.Status)
+		assert.Equal(t, orbital.JobGroupStatusFailed, result.Status)
 		assert.Equal(t, orbital.JobStatusScheduled, result.Jobs[0].Status)
 		assert.Equal(t, orbital.JobStatusScheduled, result.Jobs[1].Status)
 
-		// active group was advanced (proves scheduler ran)
+		// active job group was advanced (proves scheduler ran)
 		result, _, err = subj.GetJobGroup(ctx, activeGroup.ID)
 		assert.NoError(t, err)
-		assert.Equal(t, orbital.GroupStatusProcessing, result.Status)
+		assert.Equal(t, orbital.JobGroupStatusProcessing, result.Status)
 		assert.Equal(t, orbital.JobStatusCreated, result.Jobs[0].Status)
 		assert.Equal(t, orbital.JobStatusScheduled, result.Jobs[1].Status)
 	})
 }
 
 func TestCancelJobGroup(t *testing.T) {
-	t.Run("should cancel group", func(t *testing.T) {
+	t.Run("should cancel job group", func(t *testing.T) {
 		tests := []struct {
 			name    string
 			promote bool
@@ -1952,13 +1952,13 @@ func TestCancelJobGroup(t *testing.T) {
 				result, ok, err := subj.GetJobGroup(ctx, group.ID)
 				assert.NoError(t, err)
 				assert.True(t, ok)
-				assert.Equal(t, orbital.GroupStatusCanceled, result.Status)
-				assert.Equal(t, "group has been canceled by the user", result.ErrorMessage)
+				assert.Equal(t, orbital.JobGroupStatusCanceled, result.Status)
+				assert.Equal(t, "job group has been canceled by the user", result.ErrorMessage)
 			})
 		}
 	})
 
-	t.Run("group not found", func(t *testing.T) {
+	t.Run("job group not found", func(t *testing.T) {
 		// given
 		db, store := createSQLStore(t)
 		defer clearTables(t, db)
@@ -1974,14 +1974,14 @@ func TestCancelJobGroup(t *testing.T) {
 		assert.ErrorIs(t, err, orbital.ErrJobGroupNotFound)
 	})
 
-	t.Run("should not cancel terminal group", func(t *testing.T) {
+	t.Run("should not cancel terminal job group", func(t *testing.T) {
 		tests := []struct {
 			name   string
-			status orbital.GroupStatus
+			status orbital.JobGroupStatus
 		}{
-			{name: "DONE", status: orbital.GroupStatusDone},
-			{name: "FAILED", status: orbital.GroupStatusFailed},
-			{name: "CANCELED", status: orbital.GroupStatusCanceled},
+			{name: "DONE", status: orbital.JobGroupStatusDone},
+			{name: "FAILED", status: orbital.JobGroupStatusFailed},
+			{name: "CANCELED", status: orbital.JobGroupStatusCanceled},
 		}
 
 		for _, tt := range tests {
@@ -2017,7 +2017,7 @@ func TestCancelJobGroup(t *testing.T) {
 		}
 	})
 
-	t.Run("scheduler should not promote jobs after group is canceled", func(t *testing.T) {
+	t.Run("scheduler should not promote jobs after job group is canceled", func(t *testing.T) {
 		// given
 		db, store := createSQLStore(t)
 		defer clearTables(t, db)
@@ -2042,10 +2042,10 @@ func TestCancelJobGroup(t *testing.T) {
 		err = orbital.ScheduleJobGroup(subj)(ctx)
 		assert.NoError(t, err)
 
-		// then - jobs remain SCHEDULED, group remains CANCELED
+		// then - jobs remain SCHEDULED, job group remains CANCELED
 		result, _, err := subj.GetJobGroup(ctx, group.ID)
 		assert.NoError(t, err)
-		assert.Equal(t, orbital.GroupStatusCanceled, result.Status)
+		assert.Equal(t, orbital.JobGroupStatusCanceled, result.Status)
 		assert.Equal(t, orbital.JobStatusScheduled, result.Jobs[0].Status)
 		assert.Equal(t, orbital.JobStatusScheduled, result.Jobs[1].Status)
 	})

--- a/mapper.go
+++ b/mapper.go
@@ -288,7 +288,7 @@ func decodeJobGroup[T EntityTypes](e Entity) (T, error) {
 	if group.Type, err = resolve[string](vals, "type"); err != nil {
 		return empty, err
 	}
-	if group.Status, err = resolveType[GroupStatus](vals, "status"); err != nil {
+	if group.Status, err = resolveType[JobGroupStatus](vals, "status"); err != nil {
 		return empty, err
 	}
 	if group.ErrorMessage, err = resolve[string](vals, "error_message"); err != nil {

--- a/mapper.go
+++ b/mapper.go
@@ -205,6 +205,19 @@ func Encode[T EntityTypes](entityType T) (Entity, error) {
 				"labels":        labelsJSON,
 			},
 		}, nil
+	case JobGroupEvent:
+		return Entity{
+			Name:      query.EntityNameJobGroupEvent,
+			ID:        obj.ID,
+			CreatedAt: obj.CreatedAt,
+			UpdatedAt: obj.UpdatedAt,
+			Values: map[string]any{
+				"id":          obj.ID,
+				"is_notified": obj.IsNotified,
+				"updated_at":  obj.UpdatedAt,
+				"created_at":  obj.CreatedAt,
+			},
+		}, nil
 	default:
 		return Entity{}, fmt.Errorf("%w `%T` not supported", ErrInvalidEntityType, obj)
 	}
@@ -237,6 +250,8 @@ func Decode[T EntityTypes](entity Entity) (T, error) {
 		return decodeJobEvent[T](entity)
 	case JobGroup:
 		return decodeJobGroup[T](entity)
+	case JobGroupEvent:
+		return decodeJobGroupEvent[T](entity)
 	default:
 		return out, fmt.Errorf("%w `%T` not supported", ErrInvalidEntityType, typ)
 	}
@@ -282,6 +297,25 @@ func decodeJobGroup[T EntityTypes](e Entity) (T, error) {
 	if group.Labels, err = resolveLabels(vals, "labels"); err != nil {
 		return empty, err
 	}
+	return out, nil
+}
+
+func decodeJobGroupEvent[T EntityTypes](entity Entity) (T, error) {
+	var out, empty T
+	e, ok := any(&out).(*JobGroupEvent)
+	if !ok {
+		return empty, fmt.Errorf("%w `%T` not supported", ErrInvalidEntityType, e)
+	}
+	e.ID = entity.ID
+	e.UpdatedAt = entity.UpdatedAt
+	e.CreatedAt = entity.CreatedAt
+
+	values := entity.Values
+	isNotified, err := resolve[bool](values, "is_notified")
+	if err != nil {
+		return empty, err
+	}
+	e.IsNotified = isNotified
 	return out, nil
 }
 

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -418,7 +418,7 @@ func TestEncodes(t *testing.T) {
 			{
 				ID:           uID,
 				Type:         "batch-sync",
-				Status:       orbital.GroupStatusCreated,
+				Status:       orbital.JobGroupStatusCreated,
 				ErrorMessage: "",
 				Labels:       orbital.Labels{"env": "prod"},
 				CreatedAt:    unixTime,
@@ -434,7 +434,7 @@ func TestEncodes(t *testing.T) {
 				Values: map[string]any{
 					"id":            uID,
 					"type":          "batch-sync",
-					"status":        orbital.GroupStatusCreated,
+					"status":        orbital.JobGroupStatusCreated,
 					"error_message": "",
 					"created_at":    unixTime,
 					"updated_at":    unixTime,
@@ -455,7 +455,7 @@ func TestEncodes(t *testing.T) {
 			{
 				ID:           uID,
 				Type:         "batch-sync",
-				Status:       orbital.GroupStatusCreated,
+				Status:       orbital.JobGroupStatusCreated,
 				ErrorMessage: "",
 				Labels:       nil,
 				CreatedAt:    unixTime,
@@ -471,7 +471,7 @@ func TestEncodes(t *testing.T) {
 				Values: map[string]any{
 					"id":            uID,
 					"type":          "batch-sync",
-					"status":        orbital.GroupStatusCreated,
+					"status":        orbital.JobGroupStatusCreated,
 					"error_message": "",
 					"created_at":    unixTime,
 					"updated_at":    unixTime,
@@ -560,8 +560,8 @@ func TestDecodes(t *testing.T) {
 				UpdatedAt:    clock.NowUnixNano(),
 				CreatedAt:    clock.NowUnixNano(),
 				Labels: orbital.Labels{
-					"orbital/group-id":    uuid.New().String(),
-					"orbital/group-index": "0",
+					"orbital/job-group-id":        uuid.New().String(),
+					"orbital/job-group-order-key": "0",
 				},
 			}
 
@@ -828,7 +828,7 @@ func TestDecodes(t *testing.T) {
 			group1 := orbital.JobGroup{
 				ID:           uuid.New(),
 				Type:         "batch-sync",
-				Status:       orbital.GroupStatusCreated,
+				Status:       orbital.JobGroupStatusCreated,
 				ErrorMessage: "",
 				Labels:       orbital.Labels{"env": "prod"},
 				UpdatedAt:    clock.NowUnixNano(),
@@ -837,7 +837,7 @@ func TestDecodes(t *testing.T) {
 			group2 := orbital.JobGroup{
 				ID:           uuid.New(),
 				Type:         "full-sync",
-				Status:       orbital.GroupStatusFailed,
+				Status:       orbital.JobGroupStatusFailed,
 				ErrorMessage: "something went wrong",
 				Labels:       orbital.Labels{"env": "dev"},
 				UpdatedAt:    clock.NowUnixNano(),
@@ -860,7 +860,7 @@ func TestDecodes(t *testing.T) {
 			group := orbital.JobGroup{
 				ID:           uuid.New(),
 				Type:         "batch-sync",
-				Status:       orbital.GroupStatusCreated,
+				Status:       orbital.JobGroupStatusCreated,
 				ErrorMessage: "",
 				Labels:       nil,
 				UpdatedAt:    clock.NowUnixNano(),

--- a/repository.go
+++ b/repository.go
@@ -80,6 +80,15 @@ type (
 		RetrievalModeQueue bool          // If true, enables queue-like retrieval mode (FOR UPDATE SKIP LOCKED).
 		OrderByUpdatedAt   bool          // If true, orders groups by updated_at in ascending order.
 	}
+
+	// ListJobGroupEventQuery defines the parameters for querying job group events from the repository.
+	ListJobGroupEventQuery struct {
+		ID                 uuid.UUID // Filter job group events by their ID.
+		IsNotified         *bool     // Filter job group events by whether they have been notified.
+		RetrievalModeQueue bool      // If true, enables queue-like retrieval mode.
+		Limit              int       // Maximum number of job group events to return.
+		OrderByUpdatedAt   bool      // If true, orders job group events by updated_at in ascending order.
+	}
 )
 
 // createJob creates a new job entity in the repository.
@@ -536,4 +545,57 @@ func (r *Repository) listJobGroups(ctx context.Context, groupsQuery ListJobGroup
 	}
 
 	return listEntities[JobGroup](ctx, r, q)
+}
+
+// createJobGroupEvent creates a new job group event in the repository.
+func (r *Repository) createJobGroupEvent(ctx context.Context, event JobGroupEvent) (JobGroupEvent, error) {
+	created, err := createEntity(ctx, event, r)
+	if err != nil {
+		slogctx.Error(ctx, "failed to create job group event", "error", err)
+	}
+	return created, err
+}
+
+// getJobGroupEvent retrieves a JobGroupEvent from the repository based on the provided query.
+func (r *Repository) getJobGroupEvent(ctx context.Context, eventQuery ListJobGroupEventQuery) (JobGroupEvent, bool, error) {
+	q := query.Query{
+		EntityName:    query.EntityNameJobGroupEvent,
+		Clauses:       []query.Clause{},
+		RetrievalMode: query.RetrievalModeDefault,
+		Limit:         eventQuery.Limit,
+	}
+
+	if eventQuery.RetrievalModeQueue {
+		q.RetrievalMode = query.RetrievalModeForUpdateSkipLocked
+	}
+
+	if eventQuery.IsNotified != nil {
+		q.Clauses = append(q.Clauses, query.ClauseWithIsNotified(*eventQuery.IsNotified))
+	}
+	if eventQuery.ID != uuid.Nil {
+		q.Clauses = append(q.Clauses, query.ClauseWithID(eventQuery.ID))
+	}
+	if eventQuery.OrderByUpdatedAt {
+		q.OrderBy = append(q.OrderBy, query.OrderByUpdatedAtAscending())
+	}
+
+	event, err := getEntity[JobGroupEvent](ctx, r, q)
+	if err != nil {
+		slogctx.Error(ctx, "failed to get job group event", "error", err)
+		return JobGroupEvent{}, false, err
+	}
+	if event == nil {
+		return JobGroupEvent{}, false, nil
+	}
+
+	return *event, true, nil
+}
+
+// updateJobGroupEvent updates an existing JobGroupEvent entity in the repository.
+func (r *Repository) updateJobGroupEvent(ctx context.Context, event JobGroupEvent) error {
+	err := updateEntity(ctx, event, r)
+	if err != nil {
+		slogctx.Error(ctx, "failed to update job group event", "error", err, "groupEventId", event.ID)
+	}
+	return err
 }

--- a/repository.go
+++ b/repository.go
@@ -75,10 +75,10 @@ type (
 
 	// ListJobGroupsQuery defines the parameters for querying job groups from the repository.
 	ListJobGroupsQuery struct {
-		StatusIn           []GroupStatus // Filter groups by a list of statuses.
-		Limit              int           // Maximum number of groups to return.
-		RetrievalModeQueue bool          // If true, enables queue-like retrieval mode (FOR UPDATE SKIP LOCKED).
-		OrderByUpdatedAt   bool          // If true, orders groups by updated_at in ascending order.
+		StatusIn           []JobGroupStatus // Filter job groups by a list of statuses.
+		Limit              int              // Maximum number of job groups to return.
+		RetrievalModeQueue bool             // If true, enables queue-like retrieval mode (FOR UPDATE SKIP LOCKED).
+		OrderByUpdatedAt   bool             // If true, orders job groups by updated_at in ascending order.
 	}
 
 	// ListJobGroupEventQuery defines the parameters for querying job group events from the repository.
@@ -479,7 +479,7 @@ func (r *Repository) getJobGroup(ctx context.Context, id uuid.UUID) (JobGroup, b
 	return *group, true, nil
 }
 
-// getJobGroupForUpdate retrieves a job group entity by its ID and ensures that the group is locked for update.
+// getJobGroupForUpdate retrieves a job group entity by its ID and ensures that the job group is locked for update.
 func (r *Repository) getJobGroupForUpdate(ctx context.Context, id uuid.UUID) (JobGroup, bool, error) {
 	q := query.Query{
 		EntityName:    query.EntityNameJobGroups,
@@ -498,7 +498,7 @@ func (r *Repository) getJobGroupForUpdate(ctx context.Context, id uuid.UUID) (Jo
 // listOrderedGroupJobs retrieves all jobs belonging to a specific job group, sorted by their group order.
 func (r *Repository) listOrderedGroupJobs(ctx context.Context, groupID uuid.UUID) ([]Job, error) {
 	jobs, err := r.listJobs(ctx, ListJobsQuery{
-		Labels: Labels{LabelKeyGroupID: groupID.String()},
+		Labels: Labels{LabelKeyJobGroupID: groupID.String()},
 	})
 	if err != nil {
 		return nil, err
@@ -514,7 +514,7 @@ func (r *Repository) listOrderedGroupJobs(ctx context.Context, groupID uuid.UUID
 func (r *Repository) updateJobGroup(ctx context.Context, group JobGroup) error {
 	err := updateEntity(ctx, group, r)
 	if err != nil {
-		slogctx.Error(ctx, "failed to update job group", "error", err, "groupId", group.ID)
+		slogctx.Error(ctx, "failed to update job group", "error", err, "jobGroupId", group.ID)
 	}
 	return err
 }
@@ -595,7 +595,7 @@ func (r *Repository) getJobGroupEvent(ctx context.Context, eventQuery ListJobGro
 func (r *Repository) updateJobGroupEvent(ctx context.Context, event JobGroupEvent) error {
 	err := updateEntity(ctx, event, r)
 	if err != nil {
-		slogctx.Error(ctx, "failed to update job group event", "error", err, "groupEventId", event.ID)
+		slogctx.Error(ctx, "failed to update job group event", "error", err, "eventId", event.ID)
 	}
 	return err
 }

--- a/store.go
+++ b/store.go
@@ -35,7 +35,7 @@ type TransactionFunc func(context.Context, Repository) error
 // EntityTypes defines a type constraint for entities that can be used in the repository.
 // It allows only types Job, Task, JobCursor, JobEvent, or JobGroup to satisfy this interface.
 type EntityTypes interface {
-	Job | Task | JobCursor | JobEvent | JobGroup
+	Job | Task | JobCursor | JobEvent | JobGroup | JobGroupEvent
 }
 
 type FindResult struct {

--- a/store/query/query.go
+++ b/store/query/query.go
@@ -24,15 +24,17 @@ const (
 	EntityNameJobCursor                       EntityName = "job_cursor"
 	EntityNameJobEvent                        EntityName = "job_event"
 	EntityNameJobGroups                       EntityName = "job_groups"
+	EntityNameJobGroupEvent                   EntityName = "job_group_events"
 )
 
 // ValidEntityNames contains all valid entity names.
 var ValidEntityNames = map[EntityName]struct{}{
-	EntityNameJobs:      {},
-	EntityNameTasks:     {},
-	EntityNameJobCursor: {},
-	EntityNameJobEvent:  {},
-	EntityNameJobGroups: {},
+	EntityNameJobs:          {},
+	EntityNameTasks:         {},
+	EntityNameJobCursor:     {},
+	EntityNameJobEvent:      {},
+	EntityNameJobGroups:     {},
+	EntityNameJobGroupEvent: {},
 }
 
 type RetrievalMode int

--- a/store/sql/sql.go
+++ b/store/sql/sql.go
@@ -91,6 +91,12 @@ func New(ctx context.Context, db *sql.DB) (*SQL, error) {
 			labels JSONB,
 			updated_at BIGINT NOT NULL,
 			created_at BIGINT NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS job_group_events(
+			id UUID PRIMARY KEY,
+			is_notified BOOLEAN NOT NULL,
+			updated_at BIGINT NOT NULL,
+			created_at BIGINT NOT NULL
 		);`
 	return s, s.execContext(ctx, stmt)
 }


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       feat
- description:   implement group terminated events for JobGroup lifecycle

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
Add background notification system for job groups reaching terminal states (DONE, FAILED, CANCELED). 
