### PR TITLE
fix: remove implicit time-based filters from listTasks to prevent clo…

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -258,23 +258,20 @@ func (r *Repository) listTasks(ctx context.Context, tasksQuery ListTasksQuery) (
 		q.Clauses = append(q.Clauses, query.ClauseWithJobID(tasksQuery.JobID))
 	}
 
-	now := clock.NowUnixNano()
 	if tasksQuery.CreatedAt != 0 {
 		q.Clauses = append(q.Clauses, query.ClauseWithCreatedBefore(tasksQuery.CreatedAt))
 	}
-	q.Clauses = append(q.Clauses, query.ClauseWithCreatedBefore(now))
 
 	if tasksQuery.UpdatedAt != 0 {
 		q.Clauses = append(q.Clauses, query.ClauseWithUpdatedBefore(tasksQuery.UpdatedAt))
 	}
-	q.Clauses = append(q.Clauses, query.ClauseWithUpdatedBefore(now))
 
 	if tasksQuery.Limit > 0 {
 		q.Limit = tasksQuery.Limit
 	}
 
 	if tasksQuery.IsReconcileReady {
-		q.Clauses = append(q.Clauses, query.ClauseWithReadyToBeSent(now))
+		q.Clauses = append(q.Clauses, query.ClauseWithReadyToBeSent(clock.NowUnixNano()))
 	}
 
 	q.RetrievalMode = query.RetrievalModeDefault

--- a/repository_test.go
+++ b/repository_test.go
@@ -672,6 +672,86 @@ func TestRepoListTasks(t *testing.T) {
 	}
 }
 
+// This fixes a bug in multi-server environments where clock skew between servers caused tasks to
+// become invisible. Previously, listTasks unconditionally added updatedAt < now and createdAt < now
+// filters. If Server A (with a slightly ahead clock) updated a task, its updated_at timestamp
+// could be in the future relative to Server B. When Server B queried with its own now, the automatic
+// filter excluded those tasks. The fix removes the implicit time-based filters, applying them only
+// when explicitly provided in the query.
+func TestListTasksRaceCondition(t *testing.T) {
+	// given
+	ctx := t.Context()
+	db, store := createSQLStore(t)
+	defer clearTables(t, db)
+	repo := orbital.NewRepository(store)
+
+	t.Run("should fetch tasks regardless of their updatedAt when UpdatedAt is not provided in the query", func(t *testing.T) {
+		// given
+		jobID := uuid.New()
+		tasks := []orbital.Task{
+			{
+				JobID: jobID,
+			},
+		}
+
+		ids, err := orbital.CreateRepoTasks(repo)(ctx, tasks)
+		assert.NoError(t, err)
+		assert.Len(t, ids, 1)
+
+		// Update the updated_at timestamp of the task to a future time
+		futureTime := time.Now().Add(time.Minute).UTC().UnixNano()
+
+		// Updating this to future date to simulate a scenario where the task's updated_at is after the query's created_at filter
+		res, err := db.ExecContext(ctx, "UPDATE tasks SET updated_at = $1 WHERE id = $2", futureTime, ids[0])
+		assert.NoError(t, err)
+		rowsAffected, err := res.RowsAffected()
+		assert.NoError(t, err)
+		assert.Equal(t, int64(1), rowsAffected)
+
+		// when
+		fetchedTasks, err := orbital.ListRepoTasks(repo)(ctx, orbital.ListTasksQuery{
+			JobID: jobID,
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Len(t, fetchedTasks, 1)
+	})
+
+	t.Run("should fetch tasks regardless of their createdAt when CreatedAt is not provided in the query", func(t *testing.T) {
+		// given
+		jobID := uuid.New()
+		tasks := []orbital.Task{
+			{
+				JobID: jobID,
+			},
+		}
+
+		ids, err := orbital.CreateRepoTasks(repo)(ctx, tasks)
+		assert.NoError(t, err)
+		assert.Len(t, ids, 1)
+
+		// Update the created_at timestamp of the task to a future time
+		futureTime := time.Now().Add(time.Minute).UTC().UnixNano()
+
+		// Updating this to future date to simulate a scenario where the task's created_at is after the query's created_at filter
+		res, err := db.ExecContext(ctx, "UPDATE tasks SET created_at = $1 WHERE id = $2", futureTime, ids[0])
+		assert.NoError(t, err)
+		rowsAffected, err := res.RowsAffected()
+		assert.NoError(t, err)
+		assert.Equal(t, int64(1), rowsAffected)
+
+		// when
+		fetchedTasks, err := orbital.ListRepoTasks(repo)(ctx, orbital.ListTasksQuery{
+			JobID: jobID,
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Len(t, fetchedTasks, 1)
+	})
+}
+
 func TestRepoCreateJobCursor(t *testing.T) {
 	ctx := t.Context()
 	db, store := createSQLStore(t)


### PR DESCRIPTION

Previously, listTasks unconditionally appended  and
 clauses. In multi-server environments with clock skew,
tasks updated by a server with a slightly ahead clock became invisible to other servers whose  was behind the stored timestamp. Time-based filters are now only applied when explicitly provided in the query.
